### PR TITLE
feature: Add new module proxmox_cluster for creating/joining PVE clusters.

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -10,6 +10,8 @@ action_groups:
     - proxmox
     - proxmox_backup
     - proxmox_backup_info
+    - proxmox_cluster
+    - proxmox_cluster_join_info
     - proxmox_disk
     - proxmox_domain_info
     - proxmox_group_info

--- a/plugins/modules/proxmox_cluster.py
+++ b/plugins/modules/proxmox_cluster.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Florian Paul Azim Hoberg (@gyptazy) <florian.hoberg@credativ.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: proxmox_cluster
+version_added: 1.0.0
+short_description: Create and join Proxmox VE clusters
+description:
+  - Create and join Proxmox VE clusters with PVE nodes.
+author: Florian Paul Azim Hoberg (@gyptazy)
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  link0:
+    description:
+      - The first IP address to use for cluster communication.
+    type: str
+    required: false
+  link1:
+    description:
+      - The second IP address to use for cluster communication.
+    type: str
+    required: false
+  master_ip:
+    description:
+      - The IP address of the cluster master when joining the cluster.
+    type: str
+    required: false
+  fingerprint:
+    description:
+      - The fingerprint of the cluster master when joining the cluster.
+    type: str
+    required: false
+  cluster_name:
+    description:
+      - The cluster name to use for cluster creation.
+    type: str
+    required: false
+  state:
+    description:
+      - Possible module state to perform the required steps within the Proxmox VE API.
+    choices: ["present"]
+    type: str
+extends_documentation_fragment:
+  - community.proxmox.proxmox.actiongroup_proxmox
+  - community.proxmox.proxmox.documentation
+  - community.proxmox.attributes
+"""
+
+EXAMPLES = r"""
+- name: Create a Proxmox VE Cluster
+  community.proxmox.proxmox_cluster:
+    state: present
+    api_host: proxmoxhost
+    api_user: root@pam
+    api_password: password123
+    api_ssl_verify: false
+    link0: 10.10.1.1
+    link1: 10.10.2.1
+    cluster_name: "devcluster"
+
+- name: Join a Proxmox VE Cluster
+  community.proxmox.proxmox_cluster:
+    state: present
+    api_host: proxmoxhost
+    api_user: root@pam
+    api_password: password123
+    master_ip: "{{ primary_node }}"
+    fingerprint: "{{ cluster_fingerprint }}"
+    cluster_name: "devcluster"
+"""
+
+RETURN = r"""
+cluster:
+  description: The name of the cluster that was created or joined.
+  returned: success
+  type: str
+  sample: "devcluster"
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
+    proxmox_auth_argument_spec, ProxmoxAnsible)
+
+
+class ProxmoxClusterAnsible(ProxmoxAnsible):
+    def cluster_create(self):
+        cluster_name = self.module.params.get("cluster_name") or self.module.params.get("api_host")
+        payload = {"clustername": cluster_name}
+
+        if self.module.params.get("link0") is not None:
+            payload["link0"] = self.module.params.get("link0")
+        if self.module.params.get("link1") is not None:
+            payload["link1"] = self.module.params.get("link1")
+
+        if self.module.check_mode:
+            cluster_objects = self.proxmox_api.cluster.config.nodes.get()
+            if len(cluster_objects) > 0:
+                self.module.fail_json(msg="Error while creating cluster: Node is already part of a cluster!")
+            else:
+                self.module.exit_json(changed=True, msg="Cluster '{}' would be created (check mode).".format(cluster_name), cluster=cluster_name)
+
+        try:
+            self.proxmox_api.cluster.config.post(**payload)
+        except Exception as e:
+            self.module.fail_json(msg="Error while creating cluster: {}".format(str(e)))
+
+        self.module.exit_json(changed=True, msg="Cluster '{}' created.".format(cluster_name), cluster=cluster_name)
+
+    def cluster_join(self):
+        master_ip = self.module.params.get("master_ip")
+        fingerprint = self.module.params.get("fingerprint")
+        api_password = self.module.params.get("api_password")
+        cluster_name = self.module.params.get("cluster_name")
+        is_in_cluster = True
+
+        if self.module.check_mode:
+            cluster_objects = self.proxmox_api.cluster.status.get()
+            cluster_objects = cluster_objects[0]
+            cluster_id = cluster_objects.get("nodeid")
+
+            if cluster_id == 0:
+                is_in_cluster = False
+
+            if is_in_cluster:
+                self.module.fail_json(msg="Error while joining cluster: Node is already part of a cluster!")
+            else:
+                self.module.exit_json(changed=True, msg="Node would join the cluster '{}' (check mode).".format(cluster_name), cluster=cluster_name)
+
+        try:
+            self.proxmox_api.cluster.config.join.post(
+                hostname=master_ip,
+                fingerprint=fingerprint,
+                password=api_password
+            )
+
+        except Exception as e:
+            self.module.fail_json(msg="Error while joining the cluster: {}".format(str(e)))
+
+        self.module.exit_json(changed=True, msg="Node joined the cluster.", cluster=cluster_name)
+
+
+def proxmox_cluster_join_info_argument_spec():
+    return dict()
+
+
+def main():
+    module_args = proxmox_auth_argument_spec()
+
+    cluster_args = dict(
+        state=dict(default=None, choices=['present']),
+        cluster_name=dict(type='str'),
+        link0=dict(type='str'),
+        link1=dict(type='str'),
+        master_ip=dict(type='str'),
+        fingerprint=dict(type='str'),
+    )
+    module_args.update(cluster_args)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_one_of=[('api_password', 'api_token_id')],
+        required_together=[('api_token_id', 'api_token_secret')],
+        supports_check_mode=True,
+    )
+
+    result = dict(
+        changed=False
+    )
+
+    proxmox = ProxmoxClusterAnsible(module)
+
+    # The Proxmox VE API currently does not support leaving a cluster
+    # or removing a node from a cluster. Therefore, we only support creating
+    # and joining a cluster. (https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/config/nodes)
+    if module.params.get("state") == "present":
+        if module.params.get("master_ip") and module.params.get("fingerprint"):
+            cluster_action = proxmox.cluster_join()
+        else:
+            cluster_action = proxmox.cluster_create()
+    else:
+        cluster_action = {}
+
+    result['proxmox_cluster'] = cluster_action
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/proxmox_cluster_join_info.py
+++ b/plugins/modules/proxmox_cluster_join_info.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Florian Paul Azim Hoberg (@gyptazy) <florian.hoberg@credativ.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: proxmox_cluster_join_info
+version_added: 1.0.0
+short_description: Retrieve the join information of the Proxmox VE cluster
+description:
+  - Retrieve the join information of the Proxmox VE cluster.
+author: Florian Paul Azim Hoberg (@gyptazy)
+extends_documentation_fragment:
+  - community.proxmox.proxmox.actiongroup_proxmox
+  - community.proxmox.proxmox.documentation
+  - community.proxmox.attributes
+  - community.proxmox.attributes.info_module
+"""
+
+EXAMPLES = r"""
+- name: List existing Proxmox VE cluster join information
+  community.proxmox.proxmox_cluster_join_info:
+    api_host: proxmox1
+    api_user: root@pam
+    api_password: "{{ password | default(omit) }}"
+    api_token_id: "{{ token_id | default(omit) }}"
+    api_token_secret: "{{ token_secret | default(omit) }}"
+  register: proxmox_cluster_join
+"""
+
+RETURN = r"""
+cluster_join:
+  description: List of Proxmox VE nodes including the join information within the cluster.
+  returned: always, but can be empty
+  type: list
+  elements: dict
+  contains:
+    config_digest:
+      description: Digest of the cluster configuration.
+      type: str
+      sample: "aef68412f7976505ed083e6173b96274a281da25"
+    nodelist:
+      description: List of nodes in the cluster.
+      type: list
+      elements: dict
+      contains:
+        name:
+          description: Node name.
+          type: str
+          sample: "pve2"
+        nodeid:
+          description: Node ID.
+          type: str
+          sample: "1"
+        pve_addr:
+          description: Proxmox VE address.
+          type: str
+          sample: "10.10.10.159"
+        pve_fp:
+          description: Proxmox VE fingerprint.
+          type: str
+          sample: "08:B5:B2:F9:EC:01:0B:D0:..."
+        quorum_votes:
+          description: Quorum votes assigned to the node.
+          type: str
+          sample: "1"
+        ring0_addr:
+          description: Address for ring0.
+          type: str
+          sample: "vmbr0"
+    preferred_node:
+      description: The preferred cluster node.
+      type: str
+      sample: "pve2"
+    totem:
+      description: Totem protocol configuration.
+      type: dict
+      contains:
+        cluster_name:
+          description: Cluster name from totem.
+          type: str
+          sample: "devcluster"
+        config_version:
+          description: Config version.
+          type: str
+          sample: "1"
+        interface:
+          description: Interface configuration.
+          type: dict
+        ip_version:
+          description: IP version.
+          type: str
+          sample: "ipv4-6"
+        link_mode:
+          description: Link mode.
+          type: str
+          sample: "passive"
+        secauth:
+          description: Whether secure authentication is on.
+          type: str
+          sample: "on"
+        version:
+          description: Totem protocol version.
+          type: str
+          sample: "2"
+"""
+
+
+import traceback
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
+    proxmox_auth_argument_spec, ProxmoxAnsible)
+
+
+try:
+    import proxmoxer
+except ImportError:
+    PROXMOXER_LIBRARY = False
+    PROXMOXER_LIBRARY_IMPORT_ERROR = traceback.format_exc()
+else:
+    PROXMOXER_LIBRARY = True
+    PROXMOXER_LIBRARY_IMPORT_ERROR = None
+
+
+class ProxmoxClusterJoinInfoAnsible(ProxmoxAnsible):
+    def get_cluster_join(self):
+        try:
+            return self.proxmox_api.cluster.config.join.get()
+        except proxmoxer.core.ResourceException:
+            self.module.fail_json(msg="Node is not part of a cluster and does not have any join information.")
+        except Exception as e:
+            self.module.fail_json(msg="Error obtaining cluster join information: {}".format(str(e)))
+
+
+def proxmox_cluster_join_info_argument_spec():
+    return dict()
+
+
+def main():
+    module_args = proxmox_auth_argument_spec()
+    cluster_join_info_args = proxmox_cluster_join_info_argument_spec()
+    module_args.update(cluster_join_info_args)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_one_of=[('api_password', 'api_token_id')],
+        required_together=[('api_token_id', 'api_token_secret')],
+        supports_check_mode=True,
+    )
+    result = dict(
+        changed=False
+    )
+
+    proxmox = ProxmoxClusterJoinInfoAnsible(module)
+
+    cluster_join = proxmox.get_cluster_join()
+    result['cluster_join'] = cluster_join
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/plugins/modules/test_proxmox_cluster.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, Florian Paul Azim Hoberg (@gyptazy) <florian.hoberg@credativ.de>
+#
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+from unittest.mock import MagicMock, patch
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.proxmox.plugins.modules import proxmox_cluster
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import ProxmoxAnsible
+
+
+@pytest.fixture
+def module_args_join():
+    return {
+        "api_host": "10.10.10.76",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "state": "present",
+        "master_ip": "10.10.10.75",
+        "fingerprint": "BD:D0:A4:04:E6:05:30:74:30:E6:5A:83:78:A8:8F:F7:4C:25:71:DB:07:92:7C:A1:04:B9:CB:12:BB:3C:BE:4D",
+        "cluster_name": "devcluster"
+    }
+
+
+@pytest.fixture
+def module_args_create():
+    return {
+        "api_host": "10.10.10.76",
+        "api_user": "root@pam",
+        "api_password": "secret",
+        "state": "present",
+        "cluster_name": "devcluster",
+        "link0": "10.10.1.1",
+        "link1": "10.10.2.1",
+    }
+
+
+@patch.object(ProxmoxAnsible, "__init__", return_value=None)
+@patch.object(ProxmoxAnsible, "proxmox_api", create=True)
+def test_cluster_join(mock_api, mock_init, module_args_join):
+    module = MagicMock(spec=AnsibleModule)
+    module.params = module_args_join
+    module.check_mode = False
+
+    mock_api_instance = MagicMock()
+    mock_api.return_value = mock_api_instance
+    mock_api_instance.cluster.config.join.post.return_value = {}
+
+    module.exit_json = lambda **kwargs: (x for x in ()).throw(SystemExit(kwargs))
+    module.fail_json = lambda **kwargs: (x for x in ()).throw(SystemExit(kwargs))
+
+    proxmox = proxmox_cluster.ProxmoxClusterAnsible(module)
+    proxmox.module = module
+    proxmox.proxmox_api = mock_api_instance
+
+    with pytest.raises(SystemExit) as exc:
+        proxmox.cluster_join()
+
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert result["msg"] == "Node joined the cluster."
+    assert result["cluster"] == "devcluster"
+
+    mock_api_instance.cluster.config.join.post.assert_called_once_with(
+        hostname="10.10.10.75",
+        fingerprint=module_args_join["fingerprint"],
+        password="secret"
+    )
+
+
+@patch.object(ProxmoxAnsible, "__init__", return_value=None)
+@patch.object(ProxmoxAnsible, "proxmox_api", create=True)
+def test_cluster_create(mock_api, mock_init, module_args_create):
+    module = MagicMock(spec=AnsibleModule)
+    module.params = module_args_create
+    module.check_mode = False
+
+    mock_api_instance = MagicMock()
+    mock_api.return_value = mock_api_instance
+    mock_api_instance.cluster.config.nodes.get.return_value = []
+    mock_api_instance.cluster.config.post.return_value = {}
+
+    module.exit_json = lambda **kwargs: (x for x in ()).throw(SystemExit(kwargs))
+    module.fail_json = lambda **kwargs: (x for x in ()).throw(SystemExit(kwargs))
+
+    proxmox = proxmox_cluster.ProxmoxClusterAnsible(module)
+    proxmox.module = module
+    proxmox.proxmox_api = mock_api_instance
+
+    with pytest.raises(SystemExit) as exc:
+        proxmox.cluster_create()
+
+    result = exc.value.args[0]
+    assert result["changed"] is True
+    assert result["msg"] == "Cluster 'devcluster' created."
+    assert result["cluster"] == "devcluster"
+
+    expected_payload = {
+        "clustername": module_args_create["cluster_name"],
+        "link0": module_args_create["link0"],
+        "link1": module_args_create["link1"],
+    }
+
+    mock_api_instance.cluster.config.post.assert_called_once_with(**expected_payload)

--- a/tests/unit/plugins/modules/test_proxmox_cluster_join_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_join_info.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, Florian Paul Azim Hoberg (@gyptazy) <florian.hoberg@credativ.de>
+#
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+proxmoxer = pytest.importorskip('proxmoxer')
+
+from ansible_collections.community.proxmox.plugins.modules import proxmox_cluster_join_info
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import set_module_args
+import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
+
+
+JOIN_INFO = {
+    "config_digest": "111418c98000acfda99059d29cd89123583020a0",
+    "nodelist": [
+        {
+            "name": "pmx01",
+            "nodeid": "1",
+            "pve_addr": "10.10.10.75",
+            "pve_fp": "95:AC:F2:21:0C:09:A8:5F:06:9A:BD:0D:FB:68:8B:32:4A:26:36:DE:29:23:88:D2:49:C5:BB:91:AB:39:6E:48",
+            "quorum_votes": "1",
+            "ring0_addr": "10.10.10.75"
+        },
+        {
+            "name": "pmxcdev02",
+            "nodeid": "2",
+            "pve_addr": "10.10.10.76",
+            "pve_fp": "BD:D0:A4:04:E6:05:30:74:30:E6:5A:83:78:A8:8F:F7:4C:25:71:DB:07:92:7C:A1:04:B9:CB:12:BB:3C:BE:4D",
+            "quorum_votes": "1",
+            "ring0_addr": "10.10.10.76"
+        }
+    ],
+    "preferred_node": "pmxcdev02",
+    "totem": {
+        "cluster_name": "devcluster",
+        "config_version": "2",
+        "interface": {
+            "0": {
+                "linknumber": "0"
+            }
+        },
+        "ip_version": "ipv4-6",
+        "link_mode": "passive",
+        "secauth": "on",
+        "version": "2"
+    }
+}
+
+
+@patch('ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
+def test_without_required_parameters(connect_mock, capfd):
+    with set_module_args({}):
+        with pytest.raises(SystemExit):
+            proxmox_cluster_join_info.main()
+    out, err = capfd.readouterr()
+    assert not err
+    assert json.loads(out)["failed"]
+
+
+def mock_api_join_info(mocker):
+    cluster = mocker.MagicMock()
+    config = mocker.MagicMock()
+    join = mocker.MagicMock()
+    join.get.return_value = JOIN_INFO
+    config.join = join
+    cluster.config = config
+
+    api = mocker.MagicMock()
+    api.cluster = cluster
+    return api
+
+
+@patch('ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
+def test_cluster_join_success(connect_mock, capfd, mocker):
+    with set_module_args({
+        "api_host": "proxmoxhost",
+        "api_user": "root@pam",
+        "api_password": "supersecret"
+    }):
+        connect_mock.side_effect = lambda: mock_api_join_info(mocker)
+        proxmox_utils.HAS_PROXMOXER = True
+
+        with pytest.raises(SystemExit):
+            proxmox_cluster_join_info.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    result = json.loads(out)
+    assert result['cluster_join'] == JOIN_INFO
+    assert result['changed'] is False
+
+
+@patch('ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect')
+def test_cluster_join_node_not_in_cluster(connect_mock, capfd, mocker):
+    with set_module_args({
+        "api_host": "proxmoxhost",
+        "api_user": "root@pam",
+        "api_password": "supersecret"
+    }):
+        def raise_resource_exception():
+            raise proxmoxer.core.ResourceException("Not in cluster")
+
+        cluster = mocker.MagicMock()
+        config = mocker.MagicMock()
+        join = mocker.MagicMock()
+        join.get.side_effect = raise_resource_exception
+        config.join = join
+        cluster.config = config
+
+        api = mocker.MagicMock()
+        api.cluster = cluster
+        connect_mock.return_value = api
+
+        proxmox_utils.HAS_PROXMOXER = True
+
+        with pytest.raises(SystemExit):
+            proxmox_cluster_join_info.main()
+
+    out, err = capfd.readouterr()
+    assert not err
+    result = json.loads(out)
+    assert result['failed']
+    assert 'join information' in result['msg']
+    assert 'cluster_join' not in result


### PR DESCRIPTION
##### SUMMARY
feature: Add new module proxmox_cluster for creating/joining PVE clusters.

Fixes: #5

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
This adds a new module for creating and joining PVE clusters.

##### ADDITIONAL INFORMATION
With this module, you can now simply create a PVE cluster by running a single task without doing crazy stunts in the roles. The same applies to joining a cluster with one or more nodes.

```
- name: Create a Proxmox VE Cluster
  community.proxmox.proxmox_cluster:
    state: present
    api_host: "{{ primary_node }}"
    api_user: root@pam
    api_password: "{{ proxmox_password }}"
    api_ssl_verify: false
    link0: 10.10.1.1
    link1: 10.10.2.1
    cluster_name: "devcluster"

- name: Get join information of the Proxmox VE Cluster
  community.proxmox.proxmox_cluster_info:
    api_host: "{{ primary_node }}"
    api_user: root@pam
    api_password: "{{ proxmox_password }}"
  register: cluster_info

- name: Join a Proxmox VE Cluster
  community.proxmox.proxmox_cluster:
    state_present
    api_host: "{{ secondary_node }}"
    api_user: root@pam
    api_password: "{{ proxmox_password }}"
    master_ip: "{{ primary_node }}"
    fingerprint: "{{ cluster_fingerprint }}"
```
