### PR TITLE
Modernize unit tests a bit

### DIFF
--- a/tests/unit/plugins/modules/test_proxmox_backup.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup.py
@@ -4,12 +4,13 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
-import \
-    ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
+
+from unittest.mock import patch
+
+import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
 from ansible_collections.community.proxmox.plugins.modules import proxmox_backup
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson, AnsibleFailJson, set_module_args, ModuleTestCase)
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 
 __metaclass__ = type
 

--- a/tests/unit/plugins/modules/test_proxmox_backup_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_info.py
@@ -9,12 +9,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from unittest.mock import patch
+
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_backup_info
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_proxmox_kvm.py
+++ b/tests/unit/plugins/modules/test_proxmox_kvm.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import sys
 from unittest.mock import patch, DEFAULT
 
 import pytest

--- a/tests/unit/plugins/modules/test_proxmox_kvm.py
+++ b/tests/unit/plugins/modules/test_proxmox_kvm.py
@@ -9,16 +9,13 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import sys
+from unittest.mock import patch, DEFAULT
 
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_kvm
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (
-    patch,
-    DEFAULT,
-)
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_proxmox_kvm.py
+++ b/tests/unit/plugins/modules/test_proxmox_kvm.py
@@ -13,10 +13,6 @@ import sys
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
-mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason="The proxmoxer dependency requires python2.7 or higher",
-)
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_kvm
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import (

--- a/tests/unit/plugins/modules/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap.py
@@ -7,7 +7,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-import sys
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/plugins/modules/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap.py
@@ -8,12 +8,12 @@ __metaclass__ = type
 
 import json
 import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 proxmoxer = pytest.importorskip('proxmoxer')
 
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
 from ansible_collections.community.proxmox.plugins.modules import proxmox_snap
 import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import set_module_args

--- a/tests/unit/plugins/modules/test_proxmox_snap.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap.py
@@ -12,10 +12,6 @@ import sys
 import pytest
 
 proxmoxer = pytest.importorskip('proxmoxer')
-mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason='The proxmoxer dependency requires python2.7 or higher'
-)
 
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock, patch
 from ansible_collections.community.proxmox.plugins.modules import proxmox_snap

--- a/tests/unit/plugins/modules/test_proxmox_storage_contents_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_storage_contents_info.py
@@ -8,12 +8,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from unittest.mock import patch
+
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_storage_contents_info
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_tasks_info.py
@@ -11,7 +11,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-import sys
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/plugins/modules/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_tasks_info.py
@@ -16,10 +16,6 @@ import sys
 import pytest
 
 proxmoxer = pytest.importorskip('proxmoxer')
-mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason='The proxmoxer dependency requires python2.7 or higher'
-)
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_tasks_info
 import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils

--- a/tests/unit/plugins/modules/test_proxmox_tasks_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_tasks_info.py
@@ -12,6 +12,7 @@ __metaclass__ = type
 
 import json
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -19,7 +20,6 @@ proxmoxer = pytest.importorskip('proxmoxer')
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_tasks_info
 import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import set_module_args
 
 NODE = 'node01'

--- a/tests/unit/plugins/modules/test_proxmox_template.py
+++ b/tests/unit/plugins/modules/test_proxmox_template.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import os
-import sys
 from unittest.mock import patch, Mock
 
 import pytest

--- a/tests/unit/plugins/modules/test_proxmox_template.py
+++ b/tests/unit/plugins/modules/test_proxmox_template.py
@@ -10,13 +10,13 @@ __metaclass__ = type
 
 import os
 import sys
+from unittest.mock import patch, Mock
 
 import pytest
 
 proxmoxer = pytest.importorskip('proxmoxer')
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_template
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, Mock
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleFailJson,
     ModuleTestCase,

--- a/tests/unit/plugins/modules/test_proxmox_template.py
+++ b/tests/unit/plugins/modules/test_proxmox_template.py
@@ -14,10 +14,6 @@ import sys
 import pytest
 
 proxmoxer = pytest.importorskip('proxmoxer')
-mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason='The proxmoxer dependency requires python2.7 or higher'
-)
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_template
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch, Mock

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -9,13 +9,13 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import sys
+from unittest.mock import patch
 
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_vm_info
-from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import sys
 from unittest.mock import patch
 
 import pytest

--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -13,10 +13,6 @@ import sys
 import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
-mandatory_py_version = pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason="The proxmoxer dependency requires python2.7 or higher",
-)
 
 from ansible_collections.community.proxmox.plugins.modules import proxmox_vm_info
 from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import patch

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 paramiko
-proxmoxer < 2.0.0 ; python_version >= '2.7' and python_version <= '3.6'
-proxmoxer ; python_version > '3.6'
+proxmoxer >= 2.0.0


### PR DESCRIPTION
##### SUMMARY
Since we're using Python 3.7+, there's no need to check for Python < 2.7 (skip tests) or < 3.7 (use proxmoxer 1.x) or Python 2 in general (compat.mock).

Ref: https://github.com/ansible-collections/community.proxmox/pull/6#discussion_r2083142669

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
