### PR TITLE
proxmox_kvm: allow configuring rng0 device

### DIFF
--- a/changelogs/fragments/10114-proxmox-kvm-add-rng.yml
+++ b/changelogs/fragments/10114-proxmox-kvm-add-rng.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - proxmox_kvm - add ``rng0`` option to specify an RNG device.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -64,6 +64,7 @@ options:
       - Specify the boot order -> boot on floppy V(a), hard disk V(c), CD-ROM V(d), or network V(n).
       - For newer versions of Proxmox VE, use a boot order like V(order=scsi0;net0;hostpci0).
       - You can combine to set order.
+      - Network boot requires setting rng0 since PVE 8.3.5
     type: str
   bootdisk:
     description:
@@ -351,6 +352,9 @@ options:
   revert:
     description:
       - Revert a pending change.
+    type: str
+  rng0:
+    description: Randomness source for RNG device, for example /dev/urandom
     type: str
   sata:
     description:
@@ -1270,6 +1274,7 @@ def main():
         protection=dict(type='bool'),
         reboot=dict(type='bool'),
         revert=dict(type='str'),
+        rng0=dict(type='str'),
         sata=dict(type='dict'),
         scsi=dict(type='dict'),
         scsihw=dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
@@ -1460,6 +1465,7 @@ def main():
                               pool=module.params['pool'],
                               protection=module.params['protection'],
                               reboot=module.params['reboot'],
+                              rng0=module.params['rng0'],
                               sata=module.params['sata'],
                               scsi=module.params['scsi'],
                               scsihw=module.params['scsihw'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since PVE 8.3.5, an RNG device is required to use PXE booting. So suddenly adding an RNG device becomes a necessity. This PR adds an option for it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_kvm

