### PR TITLE
Fix action group test

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -25,7 +25,7 @@ run_action_groups = true
 name = "proxmox"
 pattern = "^.*$"
 exclusions = []
-doc_fragment = "community.general.proxmox.actiongroup_proxmox"
+doc_fragment = "community.proxmox.proxmox.actiongroup_proxmox"
 
 [sessions.build_import_check]
 run_galaxy_importer = true


### PR DESCRIPTION
##### SUMMARY
The action group test didn't work due to a bug in antsibull-nox (https://github.com/ansible-community/antsibull-nox/pull/80). Now that that bug is fixed, a misconfiguration makes it fail for community.proxmox. This fixes the config.

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
extra sanity tests
