### PR TITLE
Fixed handling warnings

### DIFF
--- a/changelogs/fragments/104-fix-warnings.yml
+++ b/changelogs/fragments/104-fix-warnings.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox module utils - fix handling warnings in LXC tasks (https://github.com/ansible-collections/community.proxmox/pull/104)

--- a/changelogs/fragments/104-fix-warnings.yml
+++ b/changelogs/fragments/104-fix-warnings.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - proxmox module utils - fix handling warnings in LXC tasks (https://github.com/ansible-collections/community.proxmox/pull/104)
+  - proxmox module utils - fix handling warnings in LXC tasks (https://github.com/ansible-collections/community.proxmox/pull/104).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -21,6 +21,7 @@ except ImportError:
 
 
 from ansible.module_utils.basic import env_fallback, missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 
 
@@ -166,7 +167,8 @@ class ProxmoxAnsible(object):
     def api_task_ok(self, node, taskid):
         try:
             status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            return status['status'] == 'stopped' and (status['exitstatus'] == 'OK' or status['exitstatus'].startswith('WARN'))
+            exitstatus = to_native(status.get('exitstatus') or '')
+            return status['status'] == 'stopped' and (exitstatus == 'OK' or exitstatus.startswith('WARN'))
         except Exception as e:
             self.module.fail_json(msg='Unable to retrieve API task ID from node %s: %s' % (node, e))
 

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -166,8 +166,7 @@ class ProxmoxAnsible(object):
     def api_task_ok(self, node, taskid):
         try:
             status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            valid_exitstatus = status['exitstatus'] == 'OK' or status['exitstatus'].startswith('WARN')
-            return status['status'] == 'stopped' and valid_exitstatus
+            return status['status'] == 'stopped' and (status['exitstatus'] == 'OK' or status['exitstatus'].startswith('WARN'))
         except Exception as e:
             self.module.fail_json(msg='Unable to retrieve API task ID from node %s: %s' % (node, e))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I broke something when I implemented #96 I did test the KVM flow, but not the LXC flow, which broke with the error below:

```
TASK [Create new container with minimal options] **********************************************************************
fatal: [localhost]: FAILED! => changed=false 
  ansible_facts:
    discovered_interpreter_python: /usr/bin/python3
  msg: 'Unable to retrieve API task ID from node lab: ''exitstatus'''
```

I changed how the function returns the API task status and tested both flows for KVM and LXC this time ;-)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
