### PR TITLE
Inventory plugins: remove deprecated disable_lookups parameter (which was set to its default anyway)

### DIFF
--- a/changelogs/fragments/108--disable_lookups.yml
+++ b/changelogs/fragments/108--disable_lookups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox inventory plugin - avoid using deprecated option when templating options (https://github.com/ansible-collections/community.proxmox/pull/108)."

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -665,7 +665,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for o in ('url', 'user', 'password', 'token_id', 'token_secret'):
             v = self.get_option(o)
             if self.templar.is_template(v):
-                v = self.templar.template(v, disable_lookups=False)
+                v = self.templar.template(v)
             setattr(self, f'proxmox_{o}', v)
 
         # some more cleanup and validation


### PR DESCRIPTION
##### SUMMARY
`Templar.template`'s parameter `disable_lookups` has been deprecated in ansible-core 2.19 (https://github.com/ansible/ansible/blob/34abc83822a4ee118cc813862ecdb8d2a6a1538b/lib/ansible/template/__init__.py#L273-L279). Inventory plugins have been using it (probably copied around from a common source), but they always set it to `False`, which happened to be the default since at least 2017 (I didn't bother to check back even more).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory plugins
