### PR TITLE
new module - proxmox_access_acl

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -29,4 +29,3 @@ action_groups:
     - proxmox_template
     - proxmox_user_info
     - proxmox_vm_info
-

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -8,6 +8,7 @@ requires_ansible: '>=2.17.0'
 action_groups:
   proxmox:
     - proxmox
+    - proxmox_access_acl
     - proxmox_backup
     - proxmox_backup_info
     - proxmox_backup_schedule
@@ -28,3 +29,4 @@ action_groups:
     - proxmox_template
     - proxmox_user_info
     - proxmox_vm_info
+

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -116,7 +116,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
             "path": path,
             "roles": roleid,
             "propagate": int(propagate),
-            f"{type}s":ugid
+            f"{type}s": ugid
         }
 
         self._put(**data)

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -11,7 +11,7 @@ module: proxmox_access_acl
 
 short_description: Management of ACLs for objects in Proxmox VE Cluster
 
-version_added: "1.0.2"
+version_added: "1.1.0"
 
 description: 
   - Setting ACLs via /access/acls to grant permission to interact with objects

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -13,7 +13,7 @@ short_description: Management of ACLs for objects in Proxmox VE Cluster
 
 version_added: "1.1.0"
 
-description: 
+description:
   - Setting ACLs via C(/access/acls) to grant permission to interact with objects.
 
 attributes:

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -95,7 +95,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
 
     def create(self, acls, path, roleid, type, ugid, propagate):
         for ace in acls:
-            if (ace["path"],ace["roleid"],ace["type"],ace["ugid"], ace["propagate"]) == (path, roleid, type, ugid, propagate):
+            if (ace["path"],ace["roleid"],ace["type"],ace["ugid"], bool(ace.get("propagate", 1))) == (path, roleid, type, ugid, propagate):
                 return False
 
         data = {
@@ -120,7 +120,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
                 continue
             if ugid and ace["ugid"] != ugid:
                 continue
-            if propagate and ace["propagate"] != propagate:
+            if propagate and bool(ace.get("propagate", 1)) != propagate:
                 continue
 
             data = {

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -109,7 +109,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
 
     def create(self, acls, path, roleid, type, ugid, propagate):
         for ace in acls:
-            if (ace["path"],ace["roleid"],ace["type"],ace["ugid"], bool(ace.get("propagate", 1))) == (path, roleid, type, ugid, propagate):
+            if (ace["path"], ace["roleid"], ace["type"], ace["ugid"], bool(ace.get("propagate", 1))) == (path, roleid, type, ugid, propagate):
                 return False
 
         data = {

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -98,6 +98,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
 
+
 class ProxmoxAccessACLAnsible(ProxmoxAnsible):
     def _get(self):
         acls = self.proxmox_api.access.acl.get()

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -54,7 +54,6 @@ extends_documentation_fragment:
   - community.proxmox.proxmox.actiongroup_proxmox
   - community.proxmox.proxmox.documentation
   - community.proxmox.attributes
-          
 author:
     - Markus Kötter (@commonism)
 '''

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -2,6 +2,7 @@
 
 # Copyright: (c) 2025, Markus Kötter <koetter@cispa.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -148,6 +148,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
             changed = True
         return changed
 
+
 def run_module():
     module_args = proxmox_auth_argument_spec()
 

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# Copyright: (c) 2025, Markus Kötter <koetter@cispa.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -101,7 +101,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
         data = {
             "path": path,
             "roles": roleid,
-            "propagate":1 if propagate else 0,
+            "propagate":int(propagate),
             f"{type}s":ugid
         }
 

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -39,7 +39,11 @@ options:
         description: id of user or group
         required: False
         type: str
-        
+extends_documentation_fragment:
+  - community.proxmox.proxmox.actiongroup_proxmox
+  - community.proxmox.proxmox.documentation
+  - community.proxmox.attributes
+          
 author:
     - Markus Kötter (@commonism)
 '''

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -107,7 +107,6 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
     def _put(self, **data):
         return self.proxmox_api.access.acl.put(**data)
 
-
     def create(self, acls, path, roleid, type, ugid, propagate):
         for ace in acls:
             if (ace["path"],ace["roleid"],ace["type"],ace["ugid"], bool(ace.get("propagate", 1))) == (path, roleid, type, ugid, propagate):

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -2,6 +2,7 @@
 
 # Copyright: (c) 2025, Markus Kötter <koetter@cispa.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-FileCopyrightText: (c) 2025, Markus Kötter <koetter@cispa.de>
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -115,7 +115,7 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
         data = {
             "path": path,
             "roles": roleid,
-            "propagate":int(propagate),
+            "propagate": int(propagate),
             f"{type}s":ugid
         }
 

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2025, Markus Kötter <koetter@cispa.de>
+# Copyright (c) 2025, Markus Kötter <koetter@cispa.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-FileCopyrightText: (c) 2025, Markus Kötter <koetter@cispa.de>
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -122,7 +122,6 @@ class ProxmoxAccessACLAnsible(ProxmoxAnsible):
         self._put(**data)
         return True
 
-
     def delete(self, acls, path, roleid, type, ugid, propagate):
         changed = False
         for ace in acls:

--- a/plugins/modules/proxmox_access_acl.py
+++ b/plugins/modules/proxmox_access_acl.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: proxmox_access_acl
+
+short_description: Management of ACLs for objects in Proxmox VE Cluster
+
+version_added: "1.0.2"
+
+description: 
+  - Setting ACLs via /access/acls to grant permission to interact with objects
+
+options:
+    state:
+        description: create or delete
+        required: true
+        choices: ['present', 'absent']
+        type: str
+    path:
+        description: Access Control Path
+        required: false
+        type: str
+    roleid:
+        description: name of the role
+        required: false
+        type: bool
+    type:
+        description: type of access control
+        choices: ["user", "group", "token"]
+        required: false
+        type: str
+    ugid:
+        description: id of user or group
+        required: False
+        type: str
+        
+author:
+    - Markus Kötter (@commonism)
+'''
+
+EXAMPLES = r'''
+- name: Create ACE
+  community.proxmox.proxmox_access_acl:
+    api_host: "{{ ansible_host }}"
+    api_password: "{{ proxmox_root_pw | default(lookup('ansible.builtin.env', 'PROXMOX_PASSWORD', default='')) }}"
+    api_user: root@pam
+
+    state: "present"
+    path: /vms/100
+    type: user
+    ugid: "a01mako@pam"
+    roleid: PVEVMUser
+    propagate: 1
+
+- name: Delete all ACEs for a given path
+  community.proxmox.proxmox_access_acl:
+    api_host: "{{ ansible_host }}"
+    api_password: "{{ proxmox_root_pw | default(lookup('ansible.builtin.env', 'PROXMOX_PASSWORD', default='')) }}"
+    api_user: root@pam
+
+    state: "absent"
+    path: /vms/100
+'''
+
+RETURN = r'''
+# These are examples of possible return values, and in general should use other names for return values.
+old_acls:
+    description: The original name param that was passed in.
+    type: list
+    returned: always
+new_acls:
+    description: The output message that the test module generates.
+    type: list
+    returned: when changed
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)
+
+class ProxmoxAccessACLAnsible(ProxmoxAnsible):
+    def _get(self):
+        acls = self.proxmox_api.access.acl.get()
+        return acls
+
+    def _put(self, **data):
+        return self.proxmox_api.access.acl.put(**data)
+
+
+    def create(self, acls, path, roleid, type, ugid, propagate):
+        for ace in acls:
+            if (ace["path"],ace["roleid"],ace["type"],ace["ugid"], ace["propagate"]) == (path, roleid, type, ugid, propagate):
+                return False
+
+        data = {
+            "path": path,
+            "roles": roleid,
+            "propagate":1 if propagate else 0,
+            f"{type}s":ugid
+        }
+
+        self._put(**data)
+        return True
+
+
+    def delete(self, acls, path, roleid, type, ugid, propagate):
+        changed = False
+        for ace in acls:
+            if path != ace["path"]:
+                continue
+            if roleid and roleid != ace["roleid"]:
+                continue
+            if type and type != ace["type"]:
+                continue
+            if ugid and ace["ugid"] != ugid:
+                continue
+            if propagate and ace["propagate"] != propagate:
+                continue
+
+            data = {
+                "path": ace["path"],
+                "roles": ace["roleid"],
+                "propagate": ace["propagate"],
+                f'{ace["type"]}s': ace["ugid"]
+            }
+
+            self._put(**data, delete="1")
+            changed = True
+        return changed
+
+def run_module():
+    module_args = proxmox_auth_argument_spec()
+
+    acl_args = dict(
+        state=dict(choices=['present', 'absent'], required=True),
+        path=dict(type='str', required=True),
+        roleid=dict(type='str', required=False),
+        type=dict(type='str', choices=["user", "group", "token"]),
+        ugid=dict(type='str'),
+        propagate=dict(type='bool', default=True),
+    )
+
+    module_args.update(acl_args)
+
+    result = dict(
+        changed=False,
+        old_acls=[],
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if module.params["state"] == "present":
+        required = frozenset({"path", "roleid", "type", "ugid"})
+        exists = frozenset(map(lambda x: x[0], filter(lambda x: x[1] is not None, module.params.items())))
+        if len(required - exists) > 0:
+            result["failed"] = True
+            result["missing_parameters"] = required - exists
+            module.fail_json(msg="The following required parameters are not provided {}".format(sorted(required - exists)), **result)
+
+    if module.check_mode:
+        module.exit_json(**result)
+
+    proxmox = ProxmoxAccessACLAnsible(module)
+
+    path = module.params["path"]
+    roleid = module.params["roleid"]
+    type = module.params["type"]
+    ugid = module.params["ugid"]
+    propagate = module.params["propagate"]
+
+    try:
+        result["old_acls"] = acls = proxmox._get()
+
+        if module.params["state"] == "present":
+            r = proxmox.create(acls, path, roleid, type, ugid, propagate)
+        else:
+            r = proxmox.delete(acls, path, roleid, type, ugid, propagate)
+
+        result['changed'] = r
+        if r:
+            result["new_acls"] = proxmox._get()
+    except Exception as e:
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -116,7 +116,6 @@ class TestProxmoxAccessACLModule(ModuleTestCase):
         assert self.mock_get.call_count == 2
         assert self.mock_put.call_count == 1
 
-
     def test_module_absent_exists(self):
         with set_module_args(
             {

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -79,7 +79,6 @@ class TestProxmoxAccessACLModule(ModuleTestCase):
         assert self.mock_get.call_count == 0
         assert self.mock_put.call_count == 0
 
-
     def test_module_present_exists(self):
         with set_module_args(
             {

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -38,6 +38,7 @@ API = {
     "api_host": "127.0.0.1",
 }
 
+
 def return_get_api():
     return [ ACE ]
 

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from unittest.mock import patch, DEFAULT
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -96,7 +96,6 @@ class TestProxmoxAccessACLModule(ModuleTestCase):
         assert self.mock_get.call_count == 1
         assert self.mock_put.call_count == 0
 
-
     def test_module_present_missing(self):
 
         with set_module_args(

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -65,7 +65,7 @@ class TestProxmoxAccessACLModule(ModuleTestCase):
             {
                 **API,
                 "state": "present",
-                "path":"/vms/100",
+                "path": "/vms/100",
                 "roleid": "PVEVMUser",
             }
         ):

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -40,7 +40,7 @@ API = {
 
 
 def return_get_api():
-    return [ ACE ]
+    return [ACE]
 
 
 class TestProxmoxAccessACLModule(ModuleTestCase):

--- a/tests/unit/plugins/modules/test_proxmox_access_acl.py
+++ b/tests/unit/plugins/modules/test_proxmox_access_acl.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import patch, DEFAULT
+
+import pytest
+
+proxmoxer = pytest.importorskip("proxmoxer")
+
+from ansible_collections.community.proxmox.plugins.modules import proxmox_kvm
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    ModuleTestCase,
+    set_module_args,
+)
+import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
+from ansible_collections.community.proxmox.plugins.modules import proxmox_access_acl
+
+ACE = {
+    "path": "/vms/100",
+    "propagate": 1,
+    "roleid": "PVEVMUser",
+    "type": "user",
+    "ugid": "a01mako@pam"
+}
+
+API = {
+    "api_user": "root@pam",
+    "api_password": "secret",
+    "api_host": "127.0.0.1",
+}
+
+def return_get_api():
+    return [ ACE ]
+
+
+class TestProxmoxAccessACLModule(ModuleTestCase):
+    def setUp(self):
+        super(TestProxmoxAccessACLModule, self).setUp()
+        proxmox_utils.HAS_PROXMOXER = True
+        self.module = proxmox_kvm
+        self.connect_mock = patch(
+            "ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect"
+        ).start()
+        self.mock_get = patch.object(proxmox_access_acl.ProxmoxAccessACLAnsible, "_get").start()
+        self.mock_put = patch.object(proxmox_access_acl.ProxmoxAccessACLAnsible, "_put").start()
+
+        self.mock_get.side_effect = return_get_api
+
+    def tearDown(self):
+        self.connect_mock.stop()
+        super(TestProxmoxAccessACLModule, self).tearDown()
+
+    def test_module_present_missing_args(self):
+        with set_module_args(
+            {
+                **API,
+                "state": "present",
+                "path":"/vms/100",
+                "roleid": "PVEVMUser",
+            }
+        ):
+            with pytest.raises(AnsibleFailJson) as exc_info:
+                proxmox_access_acl.main()
+
+        result = exc_info.value.args[0]
+        assert result["failed"] is True
+        assert result["missing_parameters"] == frozenset({'ugid', 'type'})
+        assert result["changed"] is False, result
+        assert self.mock_get.call_count == 0
+        assert self.mock_put.call_count == 0
+
+
+    def test_module_present_exists(self):
+        with set_module_args(
+            {
+                **API,
+                "state": "present",
+                **ACE,
+            }
+        ):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_access_acl.main()
+
+        result = exc_info.value.args[0]
+
+        assert result["changed"] is False
+        assert self.mock_get.call_count == 1
+        assert self.mock_put.call_count == 0
+
+
+    def test_module_present_missing(self):
+
+        with set_module_args(
+            {
+                **API,
+                "state": "present",
+                **ACE,
+                "path": "/vms/101"
+            }
+        ):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_access_acl.main()
+
+        result = exc_info.value.args[0]
+
+        assert result["changed"] is True
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 1
+
+
+    def test_module_absent_exists(self):
+        with set_module_args(
+            {
+                **API,
+                "state": "absent",
+                **ACE,
+            }
+        ):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_access_acl.main()
+
+        result = exc_info.value.args[0]
+
+        assert result["changed"] is True
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 1
+
+    def test_module_absent_missing(self):
+        with set_module_args(
+            {
+                **API,
+                "state": "absent",
+                **ACE,
+                "path": "/vms/101"
+            }
+        ):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_access_acl.main()
+
+        result = exc_info.value.args[0]
+
+        assert result["changed"] is False
+        assert self.mock_get.call_count == 1
+        assert self.mock_put.call_count == 0


### PR DESCRIPTION
create and delete ace's

##### SUMMARY
This PR adds the module proxmox_access_acl to interface /access/acl as defined [here](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/access/acl)

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
proxmox_access_acl

