### PR TITLE
feature: allow agent forwarding with paramiko

### DIFF
--- a/changelogs/fragments/130-connection-forward-agent.yml
+++ b/changelogs/fragments/130-connection-forward-agent.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_pct_remote - allow forward agent with paramiko (https://github.com/ansible-collections/community.proxmox/pull/130).

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -159,6 +159,15 @@ options:
     ini:
       - section: defaults
         key: use_persistent_connections
+  forward_agent:
+    description: "Enable SSH agent forwarding."
+    type: boolean
+    default: False
+    env:
+      - name: ANSIBLE_PARAMIKO_FORWARD_AGENT
+    ini:
+      - section: paramiko_connection
+        key: forward_agent
   banner_timeout:
     type: float
     default: 30
@@ -675,6 +684,9 @@ class Connection(ConnectionBase):
             chan.get_pty(term=os.getenv('TERM', 'vt100'), width=int(os.getenv('COLUMNS', 0)), height=int(os.getenv('LINES', 0)))
 
         display.vvv(f'EXEC {cmd}', host=self.get_option('remote_addr'))
+
+        if self.get_option('forward_agent'):
+            paramiko.agent.AgentRequestHandler(chan)
 
         cmd = to_bytes(cmd, errors='surrogate_or_strict')
 

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -304,6 +304,25 @@ def test_exec_command_with_privilege_escalation(mock_ssh, connection):
     mock_channel.sendall.assert_called_once_with(b'sudo_password\n')
 
 
+@patch('paramiko.SSHClient')
+def test_exec_command_with_forward_agent(mock_ssh, connection):
+    """ Test exec_command with forward agent """
+    mock_client = MagicMock()
+    mock_channel = MagicMock()
+    mock_transport = MagicMock()
+
+    mock_client.get_transport.return_value = mock_transport
+    mock_transport.open_session.return_value = mock_channel
+    connection._connected = True
+    connection.ssh = mock_client
+
+    connection.set_option('forward_agent', True)
+
+    with patch('paramiko.agent.AgentRequestHandler') as mock_agent_handler:
+        connection.exec_command('test command')
+        mock_agent_handler.assert_called_once_with(mock_channel)
+
+
 def test_put_file(connection):
     """ Test putting a file to the remote system """
     connection.exec_command = MagicMock()


### PR DESCRIPTION
##### SUMMARY

Allow SSH Agent Forwarding with Paramiko to allow for use with software like `pam_ssh_agent_auth` that allows sudo use with an allowed SSH connection is available. 

https://docs.paramiko.org/en/stable/api/agent.html#paramiko.agent.AgentRequestHandler

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_pct_remote

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I have validated this works with my personal proxmox setup by modifying my local `proxmox_pct_remote.py` file. This is off by default and should not interfere with any other functionality. 
