### PR TITLE
fix idempotency in proxmox_cluster_ha_groups module

### DIFF
--- a/changelogs/fragments/139-ha-group-idempotency.yml
+++ b/changelogs/fragments/139-ha-group-idempotency.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_cluster_ha_groups - fix idempotency in proxmox_cluster_ha_groups module (https://github.com/ansible-collections/community.proxmox/issues/138, https://github.com/ansible-collections/community.proxmox/pull/139).

--- a/plugins/modules/proxmox_cluster_ha_groups.py
+++ b/plugins/modules/proxmox_cluster_ha_groups.py
@@ -43,7 +43,8 @@ options:
         description: |
             List of cluster node members, where a priority can be given to each node. A resource bound to a group will run on the available nodes with the
             highest priority. If there are more nodes in the highest priority class, the services will get distributed to those nodes. The priorities have a
-            relative meaning only. The higher the number, the higher the priority. It can either be a string O(node_name:priority,node_name:priority) or an actual list of strings.
+            relative meaning only. The higher the number, the higher the priority.
+            It can either be a string C(node_name:priority,node_name:priority) or an actual list of strings.
         required: false
         type: list
         elements: str
@@ -129,7 +130,7 @@ class ProxmoxClusterHAGroupsAnsible(ProxmoxAnsible):
                 continue
 
             group["nodes"] = sorted(
-                    group.get("nodes", "").split(",")
+                group.get("nodes", "").split(",")
             )
 
             if (

--- a/plugins/modules/proxmox_cluster_ha_groups.py
+++ b/plugins/modules/proxmox_cluster_ha_groups.py
@@ -43,9 +43,10 @@ options:
         description: |
             List of cluster node members, where a priority can be given to each node. A resource bound to a group will run on the available nodes with the
             highest priority. If there are more nodes in the highest priority class, the services will get distributed to those nodes. The priorities have a
-            relative meaning only. The higher the number, the higher the priority.
+            relative meaning only. The higher the number, the higher the priority. It can either be a string O(node_name:priority,node_name:priority) or an actual list of strings.
         required: false
-        type: str
+        type: list
+        elements: str
     nofailback:
         description: |
             The CRM tries to run services on the node with the highest priority. If a node with higher priority comes online, the CRM migrates the service to
@@ -118,7 +119,7 @@ class ProxmoxClusterHAGroupsAnsible(ProxmoxAnsible):
     def create(self, groups, name, comment, nodes, nofailback, restricted):
         data = {
             "comment": comment,
-            "nodes": nodes,
+            "nodes": ",".join(nodes),
             "nofailback": int(nofailback),
             "restricted": int(restricted)
         }
@@ -126,6 +127,10 @@ class ProxmoxClusterHAGroupsAnsible(ProxmoxAnsible):
         for group in groups:
             if group["group"] != name:
                 continue
+
+            group["nodes"] = sorted(
+                    group.get("nodes", "").split(",")
+            )
 
             if (
                 group.get("comment", ""),
@@ -157,7 +162,7 @@ def run_module():
         state=dict(choices=['present', 'absent'], required=True),
         name=dict(type='str', required=True),
         comment=dict(type='str', required=False),
-        nodes=dict(type='str', required=False),
+        nodes=dict(type='list', elements='str', required=False),
         nofailback=dict(type='bool', default=False),
         restricted=dict(type='bool', default=False),
     )
@@ -177,7 +182,7 @@ def run_module():
 
     name = module.params['name']
     comment = module.params['comment']
-    nodes = module.params['nodes']
+    nodes = sorted(module.params['nodes'])
     nofailback = module.params['nofailback']
     restricted = module.params['restricted']
     try:

--- a/plugins/modules/proxmox_cluster_ha_groups.py
+++ b/plugins/modules/proxmox_cluster_ha_groups.py
@@ -144,6 +144,7 @@ class ProxmoxClusterHAGroupsAnsible(ProxmoxAnsible):
                 return True
 
         self._post(group=name, **data)
+        return True
 
     def delete(self, groups, name):
         for group in groups:


### PR DESCRIPTION
##### SUMMARY
This PR fixes the idempotency in the `proxmox_cluster_ha_groups` module.

Fixes https://github.com/ansible-collections/community.proxmox/issues/138

To fix it, I changed the param type from `str` to `list` and then sort the list provided by the user and the list provided by the api before comparing the two.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Users should still be able to pass the nodes as string, it seems ansible automatically converts the string into a list. I tested this using these changes:

```diff
diff --git a/plugins/modules/proxmox_cluster_ha_groups.py b/plugins/modules/proxmox_cluster_ha_groups.py
index e0077bb..91eec8c 100644
--- a/plugins/modules/proxmox_cluster_ha_groups.py
+++ b/plugins/modules/proxmox_cluster_ha_groups.py
@@ -179,6 +179,10 @@ def run_module():
         supports_check_mode=False
     )
 
+    import q
+    q("User supplied nodes")
+    q(module.params['nodes'])
+
     proxmox = ProxmoxClusterHAGroupsAnsible(module)
 
     name = module.params['name']
```

And this task:

```
  - name: Create HA group for all cluster nodes
    community.proxmox.proxmox_cluster_ha_groups:
      api_host: "{{ proxmox_api_host }}"
      api_user: "{{ proxmox_api_user }}"
      api_token_id: "{{ proxmox_api_token_id }}"
      api_token_secret: "{{ proxmox_api_token_secret }}"
      state: "present"
      name: all
      comment: HA group that enables a resource to run on all cluster nodes
      nodes: pve:11,pve2:10,pve3:10 # <- passed as str
      nofailback: false
      restricted: false
    delegate_to: localhost
    run_once: true
```

This is the result:

```
 0.0s run_module: "User supplied nodes"='User supplied nodes'
 0.0s run_module: module.params['nodes']=['pve:11', 'pve2:10', 'pve3:10']
```

After fixing the idempotency I noted that the module did not report `changed` if a new group was first created. This seems to be due to a missing `return True` after the `POST` request which creates the HA group
