### PR TITLE
Added parameter master_api_password

### DIFF
--- a/changelogs/fragments/140-add-master-api-password.yml
+++ b/changelogs/fragments/140-add-master-api-password.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_cluster -  Add master_api_password for authentication against master node (https://github.com/ansible-collections/community.proxmox/pull/140).

--- a/plugins/modules/proxmox_cluster.py
+++ b/plugins/modules/proxmox_cluster.py
@@ -84,6 +84,16 @@ EXAMPLES = r"""
     master_ip: "{{ primary_node }}"
     fingerprint: "{{ cluster_fingerprint }}"
     cluster_name: "devcluster"
+
+- name: Join a Proxmox VE Cluster with different API password
+    community.proxmox.proxmox_cluster:
+    api_host: proxmoxhost
+    api_user: root@pam
+    api_password: {{ joining_node_api_password }}
+    master_api_password: {{ master_node_api_password }}
+    master_ip: "{{ primary_node }}"
+    fingerprint: "{{ cluster_fingerprint }}"
+    cluster_name: "devcluster"
 """
 
 RETURN = r"""

--- a/plugins/modules/proxmox_cluster.py
+++ b/plugins/modules/proxmox_cluster.py
@@ -89,8 +89,8 @@ EXAMPLES = r"""
     community.proxmox.proxmox_cluster:
     api_host: proxmoxhost
     api_user: root@pam
-    api_password: {{ joining_node_api_password }}
-    master_api_password: {{ master_node_api_password }}
+    api_password: "{{ joining_node_api_password }}"
+    master_api_password: "{{ master_node_api_password }}"
     master_ip: "{{ primary_node }}"
     fingerprint: "{{ cluster_fingerprint }}"
     cluster_name: "devcluster"

--- a/plugins/modules/proxmox_cluster.py
+++ b/plugins/modules/proxmox_cluster.py
@@ -36,6 +36,12 @@ options:
       - The IP address of the cluster master when joining the cluster.
     type: str
     required: false
+  master_api_password:
+    description:
+      - Specify the password to authenticate with the master node.
+      - Uses the api_password parameter if not specified.
+    type: str
+    required: false
   fingerprint:
     description:
       - The fingerprint of the cluster master when joining the cluster.
@@ -127,7 +133,7 @@ class ProxmoxClusterAnsible(ProxmoxAnsible):
     def cluster_join(self):
         master_ip = self.module.params.get("master_ip")
         fingerprint = self.module.params.get("fingerprint")
-        api_password = self.module.params.get("api_password")
+        api_password = self.module.params.get("master_api_password") or self.module.params.get("api_password")
         cluster_name = self.module.params.get("cluster_name")
         is_in_cluster = True
 
@@ -180,6 +186,7 @@ def main():
         link0=dict(type='str'),
         link1=dict(type='str'),
         master_ip=dict(type='str'),
+        master_api_password=dict(type='str', no_log=True),
         fingerprint=dict(type='str'),
     )
     module_args.update(cluster_args)

--- a/plugins/modules/proxmox_cluster.py
+++ b/plugins/modules/proxmox_cluster.py
@@ -86,7 +86,7 @@ EXAMPLES = r"""
     cluster_name: "devcluster"
 
 - name: Join a Proxmox VE Cluster with different API password
-    community.proxmox.proxmox_cluster:
+  community.proxmox.proxmox_cluster:
     api_host: proxmoxhost
     api_user: root@pam
     api_password: "{{ joining_node_api_password }}"


### PR DESCRIPTION
##### SUMMARY
Introduce new, optional parameter **master_api_password** to proxmox_cluster module.
It is used for authentication against the master node.
If not set, api_password is used as before.

Fixes #166 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox_cluster

##### ADDITIONAL INFORMATION
Current implementation requires joining node and master node, sharing the same api_password.