### PR TITLE
Unit tests: skip proxmox_pct_remote test if paramiko is not present

### DIFF
--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -22,6 +22,9 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock, mock_open
 
 
+pytest.importorskip('paramiko')
+
+
 @pytest.fixture
 def connection():
     play_context = PlayContext()


### PR DESCRIPTION
##### SUMMARY
Fixes #145.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
proxmox_pct_remote unit test
