### PR TITLE
proxmox_kvm: Fix module ignores storage parameter when restoring VM f…

### DIFF
--- a/changelogs/fragments/152-fix-module_ignores_storage_param.yml
+++ b/changelogs/fragments/152-fix-module_ignores_storage_param.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_kvm: Add missing 'storage' parameter to create_vm()-call.

--- a/changelogs/fragments/152-fix-module_ignores_storage_param.yml
+++ b/changelogs/fragments/152-fix-module_ignores_storage_param.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - proxmox_kvm: Add missing 'storage' parameter to create_vm()-call.
+  - proxmox_kvm - Add missing 'storage' parameter to create_vm()-call.

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1480,6 +1480,7 @@ def main():
                               sshkeys=module.params['sshkeys'],
                               startdate=module.params['startdate'],
                               startup=module.params['startup'],
+                              storage=module.params['storage'],
                               tablet=module.params['tablet'],
                               tags=module.params['tags'],
                               target=module.params['target'],

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -461,6 +461,7 @@ options:
   storage:
     description:
       - Target storage for full clone.
+      - If restoring from archive, target storage for all disks. If omitted, storage location embedded inside archive will be used.
     type: str
   tablet:
     description:


### PR DESCRIPTION
…rom backup

##### SUMMARY
This fixes issue  #51. (storage parameter ignored when restoring VM from backup).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_kvm.py

##### ADDITIONAL INFORMATION

'storage'-parameter was missing from create_vm()-call. Added missing parameter.

(Please provide hints if something is missing.)


