### PR TITLE
Fix AttributeError in ProxmoxAnsible initialization

### DIFF
--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -81,7 +81,7 @@ class ProxmoxAnsible(object):
         if not HAS_PROXMOXER:
             module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
         if proxmoxer_version < LooseVersion('2.0'):
-            self.module.fail_json(f'Requires proxmoxer 2.0 or newer; found version {proxmoxer_version}')
+            module.fail_json(f'Requires proxmoxer 2.0 or newer; found version {proxmoxer_version}')
 
         self.module = module
         self.proxmoxer_version = proxmoxer_version


### PR DESCRIPTION
##### SUMMARY
  The module attribute was referenced before assignment when checking
  proxmoxer version, causing initialization to fail. Changed to use
  the module parameter directly before self.module is set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/proxmox.py
