### PR TITLE
Allow import content templates

### DIFF
--- a/changelogs/fragments/162-allow-import-content-templates.yml
+++ b/changelogs/fragments/162-allow-import-content-templates.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_template -  Add 'import' to allowed content types of proxmox_template, so disk images and can be used as disk images on VM creation (https://github.com/ansible-collections/community.proxmox/pull/162).

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -168,6 +168,24 @@ EXAMPLES = r"""
     url: ubuntu-20.04-standard_20.04-1_amd64.tar.gz
     checksum_algorithm: sha256
     checksum: 65d860160bdc9b98abf72407e14ca40b609417de7939897d3b58d55787aaef69
+
+- name: Upload new disk image template with minimal options
+  community.proxmox.proxmox_template:
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    content_type: import
+    src: debian-13-genericcloud-amd64.qcow2
+
+- name: Upload new ISO with minimal options
+  community.proxmox.proxmox_template:
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    content_type: import
+    src: proxmox.iso
 """
 
 import os

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -184,7 +184,7 @@ EXAMPLES = r"""
     api_user: root@pam
     api_password: 1q2w3e
     api_host: node1
-    content_type: import
+    content_type: iso
     src: proxmox.iso
 """
 

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -42,11 +42,11 @@ options:
     type: str
   content_type:
     description:
-      - Content type.
-      - Required only for O(state=present).
+      - Content type of the template.
+      - Valid values are V(vztmpl) for LXC container templates, V(iso) for ISO disc images, and V(import) for harddisk images and Open Virtual Appliances (OVA).
     type: str
     default: 'vztmpl'
-    choices: ['vztmpl', 'iso']
+    choices: ['vztmpl', 'import', 'iso']
   storage:
     description:
       - Target storage.
@@ -279,7 +279,7 @@ def main():
         src=dict(type='path'),
         url=dict(),
         template=dict(),
-        content_type=dict(default='vztmpl', choices=['vztmpl', 'iso']),
+        content_type=dict(default='vztmpl', choices=['vztmpl', 'iso', 'import']),
         storage=dict(default='local'),
         timeout=dict(type='int', default=30),
         force=dict(type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #161 

Add 'import' to allowed content types of proxmox_template, so disk images and can be used as disk images on VM creation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

proxmox_template

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- Simple one-line fix as they behave like ISOs
- Added examples as on a glance the module looks like only supporting LXC templates
