### PR TITLE
feature: add new module proxmox_cluster_ha_rules

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,6 +14,7 @@ action_groups:
     - proxmox_backup_schedule
     - proxmox_cluster
     - proxmox_cluster_ha_resources
+    - proxmox_cluster_ha_rules
     - proxmox_cluster_ha_groups
     - proxmox_cluster_join_info
     - proxmox_disk

--- a/plugins/modules/proxmox_cluster_ha_rules.py
+++ b/plugins/modules/proxmox_cluster_ha_rules.py
@@ -1,0 +1,402 @@
+#!/usr/bin/python
+
+# Copyright (c) 2025, Reto Kupferschmid <kupferschmid@puzzle.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-FileCopyrightText: (c) 2025, Reto Kupferschmid <kupferschmid@puzzle.ch>
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: proxmox_cluster_ha_rules
+
+short_description: Management of HA rules
+
+version_added: 1.4.0
+
+description:
+  - Configure ha rules C(/cluster/ha/rules).
+
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: full
+
+options:
+    affinity:
+        description: |
+            Describes whether the HA resource are supposed to be kept on the same node V(positive),
+            or are supposed to be kept on separate nodes V(negative).
+            Required if O(type=resource-affinity).
+        required: false
+        choices: ['positive', 'negative']
+        type: str
+    comment:
+        description: Description
+        required: false
+        type: str
+    disable:
+        description: Whether the HA rule is disabled. If not specified, the Proxmox API default C(false) will be used.
+        required: false
+        type: bool
+    force:
+        description: |
+          Existing rules with a specific O(type) can not be changed to the other type.
+          If V(force=true), the existing rule will be deleted and recreated with the new type.
+        required: false
+        default: false
+        type: bool
+    name:
+        description: HA rule identifier.
+        required: true
+        type: str
+    nodes:
+        description: |
+            List of cluster node members, where a priority can be given to each node. A resource bound to a group will run on the
+            available nodes with the highest priority. If there are more nodes in the highest priority class, the services will
+            get distributed to those nodes. The priorities have a
+            relative meaning only. The higher the number, the higher the priority.
+            It can either be a string C(node_name:priority,node_name:priority) or an actual list of strings.
+            Required if O(type=node-affinity).
+        required: false
+        type: list
+        elements: str
+    resources:
+        description: List of HA resource IDs. It can either be a string C(vm:100,ct:101) or an actual list of strings.
+        required: false
+        type: list
+        elements: str
+    state:
+        description: create or delete rule
+        required: true
+        choices: ['present', 'absent']
+        type: str
+    strict:
+        description: |
+            If false, the HA resource can also be moved to other nodes if there is none of the specified nodes available.
+            If not specified, the Proxmox API default C(false) will be used.
+        required: false
+        type: bool
+    type:
+        description: HA rule type.
+        required: true
+        choices: ['node-affinity', 'resource-affinity']
+        type: str
+
+extends_documentation_fragment:
+  - community.proxmox.proxmox.actiongroup_proxmox
+  - community.proxmox.proxmox.documentation
+  - community.proxmox.attributes
+
+author:
+    - Reto Kupferschmid (@rekup)
+"""
+
+EXAMPLES = r"""
+- name: Configure ha rule (node-affinity)
+  community.proxmox.proxmox_cluster_ha_rules:
+    api_host: "{{ proxmox_api_host }}"
+    api_user: "{{ proxmox_api_user }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    name: node-affinity-rule-1
+    state: present
+    type: node-affinity
+    comment: VM 100 is supposed run on proxmox02
+    nodes:
+      - proxmox01:10
+      - proxmox02:20
+    resources:
+      - vm:100
+    disable: false
+  delegate_to: localhost
+
+- name: Configure ha rule (node-affinity) - nodes and resources can also be provided as str
+  community.proxmox.proxmox_cluster_ha_rules:
+    api_host: "{{ proxmox_api_host }}"
+    api_user: "{{ proxmox_api_user }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    name: node-affinity-rule-2
+    state: present
+    type: node-affinity
+    comment: VM 100 is supposed to run on proxmox02
+    nodes: proxmox01:10,proxmox02:20
+    resources: vm:100
+    disable: false
+  delegate_to: localhost
+
+- name: Configure ha rule (resource-affinity) - resource affinity
+  community.proxmox.proxmox_cluster_ha_rules:
+    api_host: "{{ proxmox_api_host }}"
+    api_user: "{{ proxmox_api_user }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    name: resource-affinity-rule-1
+    state: present
+    type: resource-affinity
+    comment: VM 100 and 101 are supposed to be kept on the same node
+    affinity: positive
+    resources:
+      - vm:100
+      - vm:101
+    disable: false
+  delegate_to: localhost
+
+- name: Configure ha rule (resource-affinity) - resource anti-affinity
+  community.proxmox.proxmox_cluster_ha_rules:
+    api_host: "{{ proxmox_api_host }}"
+    api_user: "{{ proxmox_api_user }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    name: resource-affinity-rule-1
+    state: present
+    type: resource-affinity
+    comment: VM 100 and 101 are supposed to be kept on different nodes
+    affinity: negative
+    resources:
+      - vm:100
+      - vm:101
+    disable: false
+  delegate_to: localhost
+
+- name: Update the comment of an existing rule - this will fail if the rule does not exist yet
+  community.proxmox.proxmox_cluster_ha_rules:
+    api_host: "{{ proxmox_api_host }}"
+    api_user: "{{ proxmox_api_user }}"
+    api_token_id: "{{ proxmox_api_token_id }}"
+    api_token_secret: "{{ proxmox_api_token_secret }}"
+    name: resource-affinity-rule-1
+    state: present
+    type: resource-affinity
+    comment: My new description
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+rule:
+  description: A representation of the rule.
+  returned: success
+  type: dict
+  sample: {
+      "comment": "My first ha rule",
+      "digest": "f19acd44b43052343763cd9fd45a03b7449b3e2f",
+      "disable": 0,
+      "nodes": "proxmox01:10,proxmox02:10",
+      "order": 2,
+      "resources": "vm:100",
+      "rule": "ha-rule1",
+      "strict": 0,
+      "type": "node-affinity"
+    }
+
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
+    proxmox_auth_argument_spec,
+    ProxmoxAnsible,
+)
+
+
+class ProxmoxClusterHARuleAnsible(ProxmoxAnsible):
+    def get(self):
+        rules = self.proxmox_api.cluster.ha.rules.get()
+        return rules
+
+    def _post(self, data):
+        return self.proxmox_api.cluster.ha.rules.post(**data)
+
+    def _put(self, name, data):
+        return self.proxmox_api.cluster.ha.rules(name).put(**data)
+
+    def _delete(self, name):
+        return self.proxmox_api.cluster.ha.rules(name).delete()
+
+    def create_payload(self):
+        payload: dict = {
+            "rule": self.module.params["name"],
+            "type": self.module.params["type"],
+        }
+
+        if self.module.params["comment"] is not None:
+            payload["comment"] = self.module.params["comment"]
+
+        if self.module.params["disable"] is not None:
+            payload["disable"] = int(self.module.params["disable"])
+
+        if self.module.params["resources"] is not None:
+            payload["resources"] = ",".join(sorted(self.module.params["resources"]))
+
+        if self.module.params["type"] == "node-affinity":
+            if self.module.params["strict"] is not None:
+                payload["strict"] = int(self.module.params["strict"])
+            if self.module.params["nodes"] is not None:
+                payload["nodes"] = ",".join(sorted(self.module.params["nodes"]))
+
+        if self.module.params["type"] == "resource-affinity":
+            payload["affinity"] = self.module.params["affinity"]
+
+        return dict(sorted(payload.items()))
+
+    def create(self, existing_rule):
+        changed: bool = False
+        diff: dict = {"before": {}, "after": {}}
+
+        name = self.module.params["name"]
+
+        if existing_rule and existing_rule.get("type") != self.module.params["type"]:
+            if self.module.params["force"]:
+                diff["before"] = existing_rule.copy()
+                if not self.module.check_mode:
+                    self._delete(name=name)
+                existing_rule = {}
+            else:
+                self.module.fail_json(
+                    changed=False,
+                    msg=(
+                        "Rule %s already exists with type=%s. "
+                        "The type of an existing rule can not be changed. "
+                        "Use force=true to delete the existing rule and recreate it with type=%s"
+                        % (
+                            name,
+                            existing_rule.get("type"),
+                            self.module.params.get("type"),
+                        )
+                    ),
+                )
+
+        if existing_rule:
+            # if the rule is enabled the "disabled" key is missing from the api response
+            existing_rule.setdefault("disable", 0)
+
+            # if the rule has no comment, the "comment" key is missing from the api response
+            existing_rule.setdefault("comment", "")
+
+            # sort fields to ensure idempotency
+            for key in ["nodes", "resources"]:
+                if existing_rule.get(key, None) is not None:
+                    value_list = existing_rule.get(key).split(",")
+                    existing_rule[key] = ",".join(sorted(value_list))
+
+            payload = self.create_payload()
+            updated_rule = {**existing_rule, **payload}
+
+            diff["before"] = existing_rule
+            diff["after"] = updated_rule
+            changed = existing_rule != updated_rule
+
+            if changed and not self.module.check_mode:
+                self._put(name, payload)
+
+        else:
+            changed = True
+            payload = self.create_payload()
+
+            if not self.module.check_mode:
+                self._post(payload)
+
+                # fetch the new rule and update the diff
+                rules = self.get()
+                diff["after"] = next(
+                    (item for item in rules if item.get("rule") == name), {}
+                )
+            else:
+                diff["after"] = payload
+
+        return {"changed": changed, "rule": diff["after"], "diff": diff}
+
+    def delete(self, existing_rule, name):
+        diff: dict = {"before": {}, "after": {}}
+
+        if existing_rule:
+            diff.update({"before": existing_rule})
+            if not self.module.check_mode:
+                self._delete(name)
+            return {"changed": True, "diff": diff}
+
+        return {"changed": False, "diff": diff}
+
+
+def run_module():
+    module_args = proxmox_auth_argument_spec()
+
+    acl_args = dict(
+        affinity=dict(choices=["positive", "negative"], required=False),
+        comment=dict(type="str", required=False),
+        disable=dict(type="bool"),
+        force=dict(type="bool", default=False),
+        name=dict(type="str", required=True),
+        nodes=dict(type="list", elements="str", required=False),
+        resources=dict(type="list", elements="str", required=False),
+        state=dict(choices=["present", "absent"], required=True),
+        strict=dict(type="bool"),
+        type=dict(choices=["node-affinity", "resource-affinity"], required=True),
+    )
+
+    module_args.update(acl_args)
+
+    result = dict(
+        changed=False,
+        rule={},
+        diff={},
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_one_of=[("api_password", "api_token_id")],
+        required_together=[("api_token_id", "api_token_secret")],
+        supports_check_mode=True,
+    )
+
+    proxmox = ProxmoxClusterHARuleAnsible(module)
+
+    name = module.params["name"]
+    state = module.params["state"]
+    rule_type = module.params["type"]
+
+    try:
+        rules = proxmox.get()
+
+        existing: dict = next((item for item in rules if item.get("rule") == name), {})
+
+        # some additional parameter validation if the rule does not exist yet
+        if state == "present" and not existing:
+            if rule_type == "node-affinity":
+                for key in ["nodes", "resources"]:
+                    if module.params.get(key) is None:
+                        module.fail_json(
+                            changed=False,
+                            msg=f"parameter {key} is mandatory for new rules with type=node-affinity",
+                        )
+            if rule_type == "resource-affinity":
+                for key in ["affinity", "resources"]:
+                    if module.params.get(key) is None:
+                        module.fail_json(
+                            changed=False,
+                            msg=f"parameter {key} is mandatory for new rules with type=resource-affinity",
+                        )
+
+        if state == "present":
+            result = proxmox.create(existing)
+            result.update(**result)
+        else:
+            result = proxmox.delete(existing, name=name)
+            result.update(**result)
+
+    except Exception as e:
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
@@ -276,12 +276,14 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
     def test_update_ha_rule(self):
         self.mock_get.side_effect = [
-            [{"rule": "my-rule", "type": "node-affinity", "comment": "old comment"}]
+            [{"rule": "my-rule", "resources": "vm:100,vm:101", "type": "node-affinity", "comment": "old comment", "nodes": "pve01:10,pve02:20"}]
         ]
 
         module_params = {
             "comment": "new comment",
             "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
             "state": "present",
             "type": "node-affinity",
         }
@@ -300,17 +302,19 @@ class TestProxmoxClusterHARules(ModuleTestCase):
         assert self.mock_delete.call_count == 0
         self.mock_put.assert_called_once_with(
             "my-rule",
-            {"comment": "new comment", "rule": "my-rule", "type": "node-affinity"},
+            {"comment": "new comment", "nodes": "pve01:10,pve02:20", "resources": "vm:100,vm:101", "rule": "my-rule", "type": "node-affinity"},
         )
 
     def test_update_ha_rule_no_change(self):
         self.mock_get.side_effect = [
-            [{"rule": "my-rule", "type": "node-affinity", "comment": "new comment"}]
+            [{"rule": "my-rule", "nodes": "pve01:10,pve02:20", "resources": "vm:100,vm:101", "type": "node-affinity", "comment": "new comment"}]
         ]
 
         module_params = {
             "comment": "new comment",
             "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
             "state": "present",
             "type": "node-affinity",
         }
@@ -333,7 +337,6 @@ class TestProxmoxClusterHARules(ModuleTestCase):
         module_params = {
             "name": "my-rule",
             "state": "absent",
-            "type": "node-affinity",
             "_ansible_check_mode": True,
         }
 
@@ -355,7 +358,6 @@ class TestProxmoxClusterHARules(ModuleTestCase):
         module_params = {
             "name": "my-absent-rule",
             "state": "absent",
-            "type": "node-affinity",
         }
 
         with set_module_args(self.build_module_params(module_params)):

--- a/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
@@ -1,0 +1,471 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, Reto Kupferschmid (@rekup) <kupferschmid@puzzle.ch>
+#
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+
+from unittest.mock import patch
+
+import ansible_collections.community.proxmox.plugins.module_utils.proxmox as proxmox_utils
+from ansible_collections.community.proxmox.plugins.modules import (
+    proxmox_cluster_ha_rules,
+)
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    AnsibleExitJson,
+    AnsibleFailJson,
+    set_module_args,
+    ModuleTestCase,
+)
+
+__metaclass__ = type
+
+import pytest
+
+proxmoxer = pytest.importorskip("proxmoxer")
+
+
+class TestProxmoxClusterHARules(ModuleTestCase):
+    def setUp(self):
+        super(TestProxmoxClusterHARules, self).setUp()
+        proxmox_utils.HAS_PROXMOXER = True
+        self.module = proxmox_cluster_ha_rules
+        self.connect_mock = patch(
+            "ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect",
+        ).start()
+        self.mock_get = patch.object(
+            proxmox_cluster_ha_rules.ProxmoxClusterHARuleAnsible, "get"
+        ).start()
+        self.mock_post = patch.object(
+            proxmox_cluster_ha_rules.ProxmoxClusterHARuleAnsible, "_post"
+        ).start()
+        self.mock_put = patch.object(
+            proxmox_cluster_ha_rules.ProxmoxClusterHARuleAnsible, "_put"
+        ).start()
+        self.mock_delete = patch.object(
+            proxmox_cluster_ha_rules.ProxmoxClusterHARuleAnsible, "_delete"
+        ).start()
+
+    def tearDown(self):
+        self.connect_mock.stop()
+        self.mock_get.stop()
+        self.mock_post.stop()
+        self.mock_put.stop()
+        self.mock_delete.stop()
+        super(TestProxmoxClusterHARules, self).tearDown()
+
+    @staticmethod
+    def build_module_params(params):
+        auth_params = {
+            "api_user": "root@pam",
+            "api_password": "secret",
+            "api_host": "127.0.0.1",
+        }
+        return {**auth_params, **params}
+
+    def test_proxmox_cluster_ha_rules_without_argument(self):
+        with set_module_args({}):
+            with pytest.raises(AnsibleFailJson):
+                proxmox_cluster_ha_rules.main()
+
+    # affinity param is required for new rules of type resource-affinity
+    def test_create_ha_rule_nodes_missing_resource(self):
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "state": "present",
+            "type": "resource-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleFailJson):
+                proxmox_cluster_ha_rules.main()
+
+    # node param is required for new rules of type node-affinity
+    def test_create_ha_rule_nodes_missing_node(self):
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "resources": "vm:100,vm:101",
+            "state": "present",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleFailJson):
+                proxmox_cluster_ha_rules.main()
+
+    def test_create_ha_rule_check(self):
+        self.mock_get.side_effect = lambda: []
+
+        module_params = {
+            "affinity": "positive",
+            "comment": "My rule",
+            "name": "my-rule",
+            "nodes": "pve01:10",
+            "resources": "vm:100",
+            "state": "present",
+            "type": "node-affinity",
+            "_ansible_check_mode": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert self.mock_get.call_count == 1
+        assert self.mock_post.call_count == 0
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+
+    # new node-affinity rule with minimal parameters
+    def test_create_ha_rule_minimal_node(self):
+        self.mock_get.side_effect = [
+            [],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "nodes": "pve01:10,pve02:10",
+            "resources": "vm:100,vm:101",
+            "state": "present",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+        self.mock_post.assert_called_once_with(
+            {
+                "comment": "My rule",
+                "nodes": "pve01:10,pve02:10",
+                "resources": "vm:100,vm:101",
+                "rule": "my-rule",
+                "type": "node-affinity",
+            }
+        )
+
+    # new resource-affinity rule with minimal parameters
+    def test_create_ha_rule_minimal_resource(self):
+        self.mock_get.side_effect = [
+            [],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "affinity": "positive",
+            "resources": "vm:100,vm:101",
+            "state": "present",
+            "type": "resource-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+        self.mock_post.assert_called_once_with(
+            {
+                "affinity": "positive",
+                "comment": "My rule",
+                "resources": "vm:100,vm:101",
+                "rule": "my-rule",
+                "type": "resource-affinity",
+            }
+        )
+
+    # new node-affinity rule with minimal parameters, nodes and resources as list
+    def test_create_ha_rule_minimal_list(self):
+        self.mock_get.side_effect = [
+            [],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:10"],
+            "resources": ["vm:100", "vm:101"],
+            "state": "present",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+        self.mock_post.assert_called_once_with(
+            {
+                "comment": "My rule",
+                "nodes": "pve01:10,pve02:10",
+                "resources": "vm:100,vm:101",
+                "rule": "my-rule",
+                "type": "node-affinity",
+            }
+        )
+
+    # new node-affinity rule with all parameters
+    def test_create_ha_rule_all(self):
+        self.mock_get.side_effect = [
+            [],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
+            "state": "present",
+            "type": "node-affinity",
+            "disable": False,
+            "strict": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+        self.mock_post.assert_called_once_with(
+            {
+                "comment": "My rule",
+                "disable": 0,
+                "nodes": "pve01:10,pve02:20",
+                "resources": "vm:100,vm:101",
+                "rule": "my-rule",
+                "strict": 1,
+                "type": "node-affinity",
+            }
+        )
+
+    def test_update_ha_rule(self):
+        self.mock_get.side_effect = [
+            [{"rule": "my-rule", "type": "node-affinity", "comment": "old comment"}]
+        ]
+
+        module_params = {
+            "comment": "new comment",
+            "name": "my-rule",
+            "state": "present",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("comment") == "new comment"
+        assert self.mock_get.call_count == 1
+        assert self.mock_post.call_count == 0
+        assert self.mock_put.call_count == 1
+        assert self.mock_delete.call_count == 0
+        self.mock_put.assert_called_once_with(
+            "my-rule",
+            {"comment": "new comment", "rule": "my-rule", "type": "node-affinity"},
+        )
+
+    def test_update_ha_rule_no_change(self):
+        self.mock_get.side_effect = [
+            [{"rule": "my-rule", "type": "node-affinity", "comment": "new comment"}]
+        ]
+
+        module_params = {
+            "comment": "new comment",
+            "name": "my-rule",
+            "state": "present",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is False
+        assert self.mock_get.call_count == 1
+        assert self.mock_post.call_count == 0
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+
+    def test_delete_ha_rule_check(self):
+        self.mock_get.side_effect = [[{"rule": "my-rule", "type": "node-affinity"}]]
+
+        module_params = {
+            "name": "my-rule",
+            "state": "absent",
+            "type": "node-affinity",
+            "_ansible_check_mode": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert self.mock_get.call_count == 1
+        assert self.mock_post.call_count == 0
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+
+    def test_delete_ha_rule_not_existing(self):
+        self.mock_get.side_effect = [[{"rule": "my-rule", "type": "node-affinity"}]]
+
+        module_params = {
+            "name": "my-absent-rule",
+            "state": "absent",
+            "type": "node-affinity",
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is False
+        assert self.mock_get.call_count == 1
+        assert self.mock_post.call_count == 0
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 0
+
+    def test_update_ha_rule_change_type_no_force(self):
+        self.mock_get.side_effect = [
+            [
+                {"rule": "my-rule", "type": "resource-affinity"}
+            ],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
+            "state": "present",
+            "type": "node-affinity",
+            "disable": False,
+            "strict": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleFailJson):
+                proxmox_cluster_ha_rules.main()
+
+    def test_update_ha_rule_change_type_force_check(self):
+        self.mock_get.side_effect = [
+            [
+                {"rule": "my-rule", "type": "resource-affinity"}
+            ],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "force": True,
+            "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
+            "state": "present",
+            "type": "node-affinity",
+            "disable": False,
+            "strict": True,
+            "_ansible_check_mode": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 1
+        assert self.mock_put.call_count == 0
+        assert self.mock_post.call_count == 0
+        assert self.mock_delete.call_count == 0
+
+    def test_update_ha_rule_change_type_force(self):
+        self.mock_get.side_effect = [
+            [
+                {"rule": "my-rule", "type": "resource-affinity"}
+            ],  # first call to get does return an empty list (rule does not exist yet)
+            [{"rule": "my-rule"}],
+        ]
+
+        module_params = {
+            "comment": "My rule",
+            "force": True,
+            "name": "my-rule",
+            "nodes": ["pve01:10", "pve02:20"],
+            "resources": ["vm:100", "vm:101"],
+            "state": "present",
+            "type": "node-affinity",
+            "disable": False,
+            "strict": True,
+        }
+
+        with set_module_args(self.build_module_params(module_params)):
+            with pytest.raises(AnsibleExitJson) as exc_info:
+                proxmox_cluster_ha_rules.main()
+
+        result = exc_info.value.args[0]
+
+        assert result.get("changed") is True
+        assert result.get("rule", {}).get("rule") == "my-rule"
+        assert self.mock_get.call_count == 2
+        assert self.mock_put.call_count == 0
+        assert self.mock_delete.call_count == 1
+        self.mock_post.assert_called_once_with(
+            {
+                "comment": "My rule",
+                "disable": 0,
+                "nodes": "pve01:10,pve02:20",
+                "resources": "vm:100,vm:101",
+                "rule": "my-rule",
+                "strict": 1,
+                "type": "node-affinity",
+            }
+        )


### PR DESCRIPTION
##### SUMMARY
This pull request adds a new module to support ha rules which were introduced in PVE 9


##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME

proxmox_cluster_ha_rules

##### ADDITIONAL INFORMATION

New Modules Added:

* proxmox_cluster_ha_rules: Manage HA rules in PVE9 or higher

The new feature is described in the [High Availability Guide](https://pve.proxmox.com/wiki/High_Availability) as well as the [API documentation](https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/ha/rules/{rule}).

I was not sure how to implement the parameters, which have a default value on the api itself. For example, the parameter `strict` has a default of `0`. If we set a default of `strict=false` in the module, a rule which is currently defined with `strict=1` will change to `strict=0` if a user removes the parameter in the ansible task. I therefore chose to not set a default in the ansible module and let the api handle this.

Another thing I was not sure about was the implementation of the `affinity`, `nodes` and `resources`. These are basically required for every new rule. But if we only want to update the `comment` of an existing rule, a user might not expect them as required. I see basically two ways to implement this:

1. Always mark the parameters as required
2. Implement some logic and use `fail_json` if a user tries to create a rule (which does not exist yet) without these parameters.

I chose to go with option 2, but I'm open for other solutions
