### PR TITLE
Fix proxmox_storage does not add PBS parameters to API payload (#170)

### DIFF
--- a/plugins/modules/proxmox_storage.py
+++ b/plugins/modules/proxmox_storage.py
@@ -350,7 +350,14 @@ class ProxmoxNodeAnsible(ProxmoxAnsible):
             datastore = pbs_options.get('datastore')
             fingerprint = pbs_options.get('fingerprint')
             if not all([server, datastore, username, password]):
-                self.module.fail_json(msg="PBS storage requires 'server', 'username', 'password', 'datastore' and 'fingerprint' parameters.")
+                self.module.fail_json(msg="PBS storage requires 'server', 'username', 'password' and 'datastore' parameters.")
+            else:
+                payload['server'] = server
+                payload['username'] = username
+                payload['password'] = password
+                payload['datastore'] = datastore
+                if fingerprint:
+                  payload['fingerprint'] = fingerprint
 
         # Check Mode validation
         if self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY

Fixes #170

This PR adds the missing PBS parameters (server, datastore, etc.) to the API payload for the proxmox_storage module.

The rationale and detailed problem description are available in the linked issue. This change directly implements the required fix.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

proxmox_storage

##### ADDITIONAL INFORMATION

This change allows the module to successfully create PBS-type storage.

Before fix: The task fails with a 500 Internal Server Error, as detailed in #170.

```
Failed to create storage: 500 Internal Server Error: missing value for required option 'datastore'
```
After fix: The task succeeds.
