### PR TITLE
Add ignores for ansible.module_utils.six

### DIFF
--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,2 @@
+plugins/inventory/proxmox.py pylint:ansible-bad-import-from
+plugins/plugin_utils/unsafe.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.20.txt.license
+++ b/tests/sanity/ignore-2.20.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible/ansible/pull/85651

Since this collection no longer supports Python 2.7 it would be better to get rid of these imports instead, but as a first step this fixes CI (which is currently broken due to the ansible-core PR).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity test ignore files
