### PR TITLE
Add source option for proxmox_tasks_info

### DIFF
--- a/changelogs/fragments/179-add-source-option-to-tasks-info.yaml
+++ b/changelogs/fragments/179-add-source-option-to-tasks-info.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_tasks_info - add source option to specify tasks to consider (https://github.com/ansible-collections/community.proxmox/pull/179)


### PR DESCRIPTION
##### SUMMARY

Add option to be able to consider all tasks

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`proxmox_tasks_info`

##### ADDITIONAL INFORMATION

Currently, it's only possible to list archived/finished tasks. As we can see here (https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/tasks), it's the default behavior of API call when no `source` option is specified.
This PR add the possibility to specify other source (and therefore to list active tasks). The default remains to only consider archived tasks in order to avoid introducing a breaking change.