### PR TITLE
proxmox_user can't create user on PVE 9 #163

### DIFF
--- a/changelogs/fragments/163-proxmox-cant-create-user-bugfix.yml
+++ b/changelogs/fragments/163-proxmox-cant-create-user-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_user - added a third case when testing for not-yet-existant user (https://github.com/ansible-collections/community.proxmox/issues/163)

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -143,7 +143,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
             user_data = self.proxmox_api.access.users(userid).get()
             return user_data
         except Exception as e:
-            if "does not exist" in str(e).lower() or "not found" in str(e).lower():
+            if "does not exist" in str(e).lower() or "not found" in str(e).lower() or "no such user" in str(e).lower():
                 return False
             else:
                 self.module.fail_json(msg="Unable to retrieve user {0}: {1}".format(userid, e))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #163
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Simple change of adding another possible string match, found in this github comment:
https://github.com/ansible-collections/community.proxmox/issues/163#issuecomment-3281511010
I've verified that the fix does work and believe it to be safe.
