### PR TITLE
proxmox: Add delete parameter to delete settings

### DIFF
--- a/changelogs/fragments/195-proxmox-delete-parameter.yml
+++ b/changelogs/fragments/195-proxmox-delete-parameter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox - Add delete parameter to delete settings (https://github.com/ansible-collections/community.proxmox/pull/195).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -110,6 +110,11 @@ options:
       - Some features require the use of a privileged container.
     type: list
     elements: str
+  delete:
+    description:
+      - A list of settings you want to delete.
+    type: list
+    elements: str
   startup:
     description:
       - Specifies the startup order of the container.
@@ -707,6 +712,7 @@ def get_proxmox_args():
         ),
         onboot=dict(type="bool"),
         features=dict(type="list", elements="str"),
+        delete=dict(type="list", elements="str"),
         startup=dict(type="list", elements="str"),
         storage=dict(default="local"),
         cpuunits=dict(type="int"),
@@ -876,6 +882,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                     disk=self.params.get("disk"),
                     disk_volume=self.params.get("disk_volume"),
                     features=self.params.get("features"),
+                    delete=self.params.get("delete"),
                     hookscript=self.params.get("hookscript"),
                     hostname=self.params.get("hostname"),
                     ip_address=self.params.get("ip_address"),
@@ -1055,6 +1062,8 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             kwargs["features"] = ",".join(kwargs.pop("features"))
         if "startup" in kwargs:
             kwargs["startup"] = ",".join(kwargs.pop("startup"))
+        if "delete" in kwargs:
+            kwargs["delete"] = ",".join(kwargs.pop("delete"))
 
         disk_updates = self.process_disk_keys(
             vmid,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add delete parameter to delete settings

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Currently we can't delete any settings for a vm
For example: when creating LXC I did it with 2 netif 1 which has internet access and another for internal use.
Afterwards I was trying to delete net0 I tried by just passing netif=net1 but that doesn't delete network instead there will be 2 networks with same config.
To fix this we need to send delete=net0 command  
