### PR TITLE
Remove ansible.module_utils.six dependency

### DIFF
--- a/changelogs/fragments/201-six.yml
+++ b/changelogs/fragments/201-six.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "proxmox_kvm, proxmox_template - remove ``ansible.module_utils.six`` dependency (https://github.com/ansible-collections/community.proxmox/pull/201)."

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -913,7 +913,7 @@ msg:
 
 import re
 import time
-from ansible.module_utils.six.moves.urllib.parse import quote
+from urllib.parse import quote
 
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (proxmox_auth_argument_spec, ProxmoxAnsible)

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -191,10 +191,10 @@ EXAMPLES = r"""
 import os
 import time
 import traceback
+from urllib.parse import urlparse, urlencode
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible_collections.community.proxmox.plugins.module_utils.proxmox import proxmox_auth_argument_spec, ProxmoxAnsible
-from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode
 
 REQUESTS_TOOLBELT_ERR = None
 try:


### PR DESCRIPTION
##### SUMMARY
It looks like I overlooked two places where six was used - likely because ansible-test's pylint sanity test didn't flag them...

##### ISSUE TYPE
- Refactor Pull Request

##### COMPONENT NAME
proxmox_kvm
proxmox_template
