### PR TITLE
Add User-Agent for inventory requests

### DIFF
--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -202,6 +202,7 @@ want_proxmox_nodes_ansible_host: true
 
 import itertools
 import re
+from sys import version as python_version
 from urllib.parse import urlencode
 
 from ansible.module_utils.common._collections_compat import MutableMapping
@@ -209,6 +210,7 @@ from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.utils.display import Display
+from ansible.module_utils.ansible_release import __version__ as ansible_version
 
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.proxmox.plugins.plugin_utils.unsafe import make_unsafe
@@ -254,6 +256,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def _get_session(self):
         if not self.session:
             self.session = requests.session()
+            self.session.headers.update({
+                'User-Agent': f"ansible {ansible_version} Python {python_version.split(' ', 1)[0]}"
+            })
             self.session.verify = self.get_option('validate_certs')
         return self.session
 


### PR DESCRIPTION
##### SUMMARY

Add User-Agent to all requests of proxmox inventory plugin.

When using this plugin to connect to proxmox over OPNSense firewall that runs nginx, by default all requests get blocked due to the User-Agent being the default 'python-requests'. This changes sets the User-Agent to some non-default to avoid getting blocked. See https://github.com/home-assistant/android/issues/1364 for a similar issue on the HomeAssistant Android app.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**Reproduction scenario**
1. Setup nginx to ban IP addresses for User-Agent == 'python-requests' and forward eg. https://pve.example.com to the Proxmox node/cluster
2. Set url in proxmox inventory config file to the nginx URL
3. Verify that 403 is returned and IP was banned

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Output before change**
```paste below
Using inventory plugin 'ansible_collections.community.proxmox.plugins.inventory.proxmox' to process inventory source '/workdir/inventory/my.proxmox.yml'
[WARNING]: Failed to parse inventory with 'ansible_collections.community.proxmox.plugins.inventory.proxmox' plugin: Expecting value: line 1 column 1 (char 0)

Failed to parse inventory with 'ansible_collections.community.proxmox.plugins.inventory.proxmox' plugin.

<<< caused by >>>

Expecting value: line 1 column 1 (char 0)
Origin: <inventory plugin 'ansible_collections.community.proxmox.plugins.inventory.proxmox' with source '/workdir/inventory/k3s.proxmox.yml'>

<<< caused by >>>

Expecting value: line 1 column 1 (char 0)
```

**Output after change**
```paste below
Loading collection community.proxmox from /root/.ansible/collections/ansible_collections/community/proxmox
Loading collection ansible.builtin from 
Parsed /workdir/inventory/my.proxmox.yml inventory source with ansible_collections.community.proxmox.plugins.inventory.proxmox plugin
```