### PR TITLE
fix: use GiB units for disk size in documentation

### DIFF
--- a/changelogs/fragments/236-fix-size-units-in-docs.yaml
+++ b/changelogs/fragments/236-fix-size-units-in-docs.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - proxmox - change disk size units to GiB (https://github.com/ansible-collections/community.proxmox/pull/236).
+  - proxmox_disk - change disk size units to GiB (https://github.com/ansible-collections/community.proxmox/pull/236).
+  - proxmox_kvm - change disk size units to GiB (https://github.com/ansible-collections/community.proxmox/pull/236).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -38,7 +38,7 @@ options:
     type: str
   disk:
     description:
-      - This option was previously described as "hard disk size in GB for instance" however several formats describing a lxc
+      - This option was previously described as "hard disk size in GiB for instance" however several formats describing a lxc
         mount are permitted.
       - Older versions of Proxmox will accept a numeric value for size using the O(storage) parameter to automatically choose
         which storage to allocate from, however new versions enforce the C(<STORAGE>:<SIZE>) syntax.
@@ -425,7 +425,7 @@ EXAMPLES = r"""
     netif:
       net0: "name=eth0,gw=192.168.0.1,ip=192.168.0.2/24,ip6=fe80::1227/64,gw6=fe80::1,bridge=vmbr0,firewall=1,tag=934,mtu=1500"
 
-- name: Create new container with minimal options defining a mount with 8GB
+- name: Create new container with minimal options defining a mount with 8GiB
   community.proxmox.proxmox:
     vmid: 100
     node: uk-mc02
@@ -438,7 +438,7 @@ EXAMPLES = r"""
     mounts:
       mp0: "local:8,mp=/mnt/test/"
 
-- name: Create new container with minimal options defining a mount with 8GB using mount_volumes
+- name: Create new container with minimal options defining a mount with 8GiB using mount_volumes
   community.proxmox.proxmox:
     vmid: 100
     node: uk-mc02

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -70,7 +70,7 @@ options:
     type: str
   size:
     description:
-      - Desired volume size in GB to allocate when O(state=present) (specify O(size) without suffix).
+      - Desired volume size in GiB to allocate when O(state=present) (specify O(size) without suffix).
       - New (or additional) size of volume when O(state=resized). With the V(+) sign the value is added to the actual size
         of the volume and without it, the value is taken as an absolute one.
     type: str

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -222,7 +222,7 @@ options:
       - Keys allowed are - V(ide[n]) where 0 ≤ n ≤ 3.
       - Values allowed are - V("storage:size,format=value").
       - V(storage) is the storage identifier where to create the disk.
-      - V(size) is the size of the disk in GB.
+      - V(size) is the size of the disk in GiB.
       - V(format) is the drive's backing file's data format. V(qcow2|raw|subvol). Please refer to the Proxmox VE Administrator
         Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest version,
         tables 3 to 14) to find out format supported by the provided storage backend.
@@ -370,7 +370,7 @@ options:
       - Keys allowed are - C(sata[n]) where 0 ≤ n ≤ 5.
       - Values allowed are - C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
-      - C(size) is the size of the disk in GB.
+      - C(size) is the size of the disk in GiB.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol). Please refer to the Proxmox VE Administrator
         Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest version,
         tables 3 to 14) to find out format supported by the provided storage backend.
@@ -381,7 +381,7 @@ options:
       - Keys allowed are - C(scsi[n]) where 0 ≤ n ≤ 13.
       - Values allowed are - C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
-      - C(size) is the size of the disk in GB.
+      - C(size) is the size of the disk in GiB.
       - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol). Please refer to the Proxmox VE Administrator
         Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest version,
         tables 3 to 14) to find out format supported by the provided storage backend.
@@ -553,7 +553,7 @@ options:
       - Keys allowed are - V(virtio[n]) where 0 ≤ n ≤ 15.
       - Values allowed are - V(storage:size,format=value).
       - V(storage) is the storage identifier where to create the disk.
-      - V(size) is the size of the disk in GB.
+      - V(size) is the size of the disk in GiB.
       - V(format) is the drive's backing file's data format. V(qcow2|raw|subvol). Please refer to the Proxmox VE Administrator
         Guide, section Proxmox VE Storage (see U(https://pve.proxmox.com/pve-docs/chapter-pvesm.html) for the latest version,
         tables 3 to 14) to find out format supported by the provided storage backend.
@@ -624,7 +624,7 @@ EXAMPLES = r"""
     cores: 4
     vcpus: 2
 
-- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot disabled by default
+- name: Create VM with 1 10GiB SATA disk and an EFI disk, with Secure Boot disabled by default
   community.proxmox.proxmox_kvm:
     api_user: root@pam
     api_password: secret
@@ -640,7 +640,7 @@ EXAMPLES = r"""
       efitype: 4m
       pre_enrolled_keys: false
 
-- name: Create VM with 1 10GB SATA disk and an EFI disk, with Secure Boot enabled by default
+- name: Create VM with 1 10GiB SATA disk and an EFI disk, with Secure Boot enabled by default
   community.proxmox.proxmox_kvm:
     api_user: root@pam
     api_password: secret


### PR DESCRIPTION
##### SUMMARY
Changed disk size units from GB to GiB in three modules to match both the Proxmox GUI and API documentation (which use GiB for disk images and mountpoints).

Fixes #235

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- proxmox
- proxmox_disk
- proxmox_kvm

