### PR TITLE
Update documentation for volume import parameter

### DIFF
--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -163,6 +163,7 @@ options:
       - Import volume from this existing one.
       - Volume string format.
       - V(<STORAGE>:<VMID>/<FULL_NAME>) or V(<ABSOLUTE_PATH>/<FULL_NAME>).
+      - V(<STORAGE>:import/<FULL_NAME>) for PVE 9.x and later, to use storage's import directory.
       - Attention! Only root can use absolute paths.
       - This parameter is mutually exclusive with O(size).
       - Increase O(timeout) parameter when importing large disk images or using slow storage.


### PR DESCRIPTION
Added note for PVE 9.x import directory usage.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #223 and adds description for using import storage option of 9.x PVE
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.proxmox.disks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR just updates the documentation to reference the since 9.x supported way of adding disks via the storage import directory as reference in [proxmox support forum](https://forum.proxmox.com/threads/creating-disk-from-cloud-init-image-in-import.164487) and [PVE-Mailing List](https://lists.proxmox.com/pipermail/pve-devel/2025-April/069618.html)
<!--- Paste verbatim command output below, e.g. before and after your change -->

