### PR TITLE
Replace deprecated ansible.module_utils.common._collections_compat

### DIFF
--- a/changelogs/fragments/241-replace-deprecated-collections-compat.yaml
+++ b/changelogs/fragments/241-replace-deprecated-collections-compat.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory plugin, plugin_utils - replace deprecated ``ansible.module_utils.common._collections_compat`` imports with ``collections.abc`` from the Python standard library (https://github.com/ansible-collections/community.proxmox/issues/241).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -205,7 +205,7 @@ import re
 from sys import version as python_version
 from urllib.parse import urlencode
 
-from ansible.module_utils.common._collections_compat import MutableMapping
+from collections.abc import MutableMapping
 
 from ansible.errors import AnsibleError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable

--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 import re
 
-from ansible.module_utils.common._collections_compat import Mapping, Set
+from collections.abc import Mapping, Set
 from ansible.module_utils.common.collections import is_sequence
 from ansible.utils.unsafe_proxy import (
     AnsibleUnsafe,


### PR DESCRIPTION
##### SUMMARY
Replace deprecated `ansible.module_utils.common._collections_compat` imports with `collections.abc` from the Python standard library.

The `_collections_compat` module is deprecated and will be removed in ansible-core 2.24.

Fixes #241
##### ISSUE TYPE
- Bugfix Pull Request