### PR TITLE
Update (re)size description in proxmox_disk.py

### DIFF
--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -72,7 +72,7 @@ options:
     description:
       - Desired volume size in GiB to allocate when O(state=present) (specify O(size) without suffix).
       - New (or additional) size of volume when O(state=resized). With the V(+) sign the value is added to the actual size
-        of the volume and without it, the value is taken as an absolute one.
+        of the volume and without it, the value is taken as an absolute one (specify O(size) with suffix V(KMGT)).
     type: str
   bwlimit:
     description:


### PR DESCRIPTION
Clarified size description for volume resizing, in contrast to "creating" for resize it is required to provide a unit

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #249 - adds missing/clarifying info that resizing a disk requires a storage unit suffix i.e. _20G_ 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_disk.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
