### PR TITLE
Add global option to specify an alternate ca path

### DIFF
--- a/changelogs/fragments/256-add-ca-path-option.yaml
+++ b/changelogs/fragments/256-add-ca-path-option.yaml
@@ -1,2 +1,4 @@
 major_changes:
   - proxmox - Add ca_path option to specify a ca-certificate for tls validation (https://github.com/ansible-collections/community.proxmox/pull/256).
+deprecated_features:
+  - proxmox - Certificate verification default changes from ``false`` to ``true`` with version 2.0.0 (https://github.com/ansible-collections/community.proxmox/pull/256).

--- a/changelogs/fragments/256-add-ca-path-option.yaml
+++ b/changelogs/fragments/256-add-ca-path-option.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - proxmox - Add ca_path option to specify a ca-certificate for tls validation (https://github.com/ansible-collections/community.proxmox/pull/256).

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -51,16 +51,15 @@ options:
     type: path
   api_timeout:
     description:
-      - Time limit for requests towards the Proxmox api.
+      - Time limit for requests towards the Proxmox VE API.
     type: int
     default: 5
   validate_certs:
     description:
-      - If V(false), SSL certificates will not be validated.
-      - This should only be used on personally controlled sites using self-signed certificates.
+      - Validate the TLS certificates used for the connection to the Proxmox VE API.  
+      - Currently defaults to V(false) and changes default to V(true) with community.proxmox 2.0.0.
       - Uses the E(PROXMOX_VALIDATE_CERTS) environment variable if not specified.
     type: bool
-    default: false
 requirements: ["proxmoxer >= 2.0", "requests"]
 """
 

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -46,16 +46,16 @@ options:
     type: str
   ca_path:
     description:
-      - Path to a local certificate, which will be used to verify tls connections.
+      - Path to a local certificate, which will be used to verify TLS connections.
       - Ignored if O(validate_certs=false).
-    type: str
+    type: path
   validate_certs:
     description:
       - If V(false), SSL certificates will not be validated.
       - This should only be used on personally controlled sites using self-signed certificates.
       - Uses the E(PROXMOX_VALIDATE_CERTS) environment variable if not specified.
     type: bool
-    default: true
+    default: false
 requirements: ["proxmoxer >= 2.0", "requests"]
 """
 

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -2,11 +2,10 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
 
 
-class ModuleDocFragment(object):
+
+class ModuleDocFragment:
     # Common parameters for Proxmox VE modules
     DOCUMENTATION = r"""
 options:

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) Ansible project
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -56,7 +55,7 @@ options:
     default: 5
   validate_certs:
     description:
-      - Validate the TLS certificates used for the connection to the Proxmox VE API.  
+      - Validate the TLS certificates used for the connection to the Proxmox VE API.
       - Currently defaults to V(false) and changes default to V(true) with community.proxmox 2.0.0.
       - Uses the E(PROXMOX_VALIDATE_CERTS) environment variable if not specified.
     type: bool

--- a/plugins/doc_fragments/proxmox.py
+++ b/plugins/doc_fragments/proxmox.py
@@ -44,13 +44,18 @@ options:
       - Specify the token secret.
       - Uses the E(PROXMOX_TOKEN_SECRET) environment variable if not specified.
     type: str
+  ca_path:
+    description:
+      - Path to a local certificate, which will be used to verify tls connections.
+      - Ignored if O(validate_certs=false).
+    type: str
   validate_certs:
     description:
       - If V(false), SSL certificates will not be validated.
       - This should only be used on personally controlled sites using self-signed certificates.
       - Uses the E(PROXMOX_VALIDATE_CERTS) environment variable if not specified.
     type: bool
-    default: false
+    default: true
 requirements: ["proxmoxer >= 2.0", "requests"]
 """
 

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -52,7 +52,7 @@ def proxmox_to_ansible_bool(value):  # noqa: SIM210
     Returns:
         bool: True if value = `1`, False for everything else including non-integers.
     """
-    bool(isinstance(value, int) and value == 1)
+    return bool(isinstance(value, int) and value == 1)
 
 
 def ansible_to_proxmox_bool(value):

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -150,12 +150,14 @@ class ProxmoxAnsible(object):
         api_token_secret = self.module.params['api_token_secret']
         if self.module.params['validate_certs'] is None:
             self.module.deprecate("The connection setting `validate_certs` was not provided and "
-                                  "defaults to true. This default will change to `false` in"
+                                  "defaults to `false`. This default will change to `true` in"
                                   "in community.proxmox 2.0.0.",
                                   version="2.0.0",
                                   collection_name="community.proxmox",
                                   )
             self.module.params['validate_certs'] = False
+        # Only push the cert path as a string to proxmoxer, if validation is required
+        # verify_ssl supports True, False or Path as values
         if self.module.params["ca_path"] and self.module.params['validate_certs']:
             validate_certs = self.module.params["ca_path"]
         else:

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -1,11 +1,7 @@
-# -*- coding: utf-8 -*-
-#
 # Copyright (c) 2020, Tristan Le Guern <tleguern at bouledef.eu>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
 import traceback
 from time import sleep
@@ -14,6 +10,7 @@ PROXMOXER_IMP_ERR = None
 try:
     from proxmoxer import ProxmoxAPI
     from proxmoxer import __version__ as proxmoxer_version
+
     HAS_PROXMOXER = True
 except ImportError:
     HAS_PROXMOXER = False
@@ -22,50 +19,31 @@ except ImportError:
 
 from ansible.module_utils.basic import env_fallback, missing_required_lib
 from ansible.module_utils.common.text.converters import to_native
+
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 
 
 def proxmox_auth_argument_spec():
     return dict(
-        api_host=dict(type='str',
-                      required=True,
-                      fallback=(env_fallback, ['PROXMOX_HOST'])
-                      ),
-        api_port=dict(type='int',
-                      fallback=(env_fallback, ['PROXMOX_PORT'])
-                      ),
-        api_user=dict(type='str',
-                      required=True,
-                      fallback=(env_fallback, ['PROXMOX_USER'])
-                      ),
-        api_password=dict(type='str',
-                          no_log=True,
-                          fallback=(env_fallback, ['PROXMOX_PASSWORD'])
-                          ),
-        api_token_id=dict(type='str',
-                          no_log=False,
-                          fallback=(env_fallback, ['PROXMOX_TOKEN_ID'])
-                          ),
-        api_token_secret=dict(type='str',
-                              no_log=True,
-                              fallback=(env_fallback, ['PROXMOX_TOKEN_SECRET'])
-                              ),
-        ca_path=dict(type='path',fallback=(env_fallback, ['PROXMOX_CA_PATH'])),
-        validate_certs=dict(type='bool',fallback=(env_fallback, ['PROXMOX_VALIDATE_CERTS'])),
-        api_timeout=dict(type='int',
-                         default=5,
-                         fallback=(env_fallback, ['PROXMOX_API_TIMEOUT'])
-                         ),
+        api_host=dict(type="str", required=True, fallback=(env_fallback, ["PROXMOX_HOST"])),
+        api_port=dict(type="int", fallback=(env_fallback, ["PROXMOX_PORT"])),
+        api_user=dict(type="str", required=True, fallback=(env_fallback, ["PROXMOX_USER"])),
+        api_password=dict(type="str", no_log=True, fallback=(env_fallback, ["PROXMOX_PASSWORD"])),
+        api_token_id=dict(type="str", no_log=False, fallback=(env_fallback, ["PROXMOX_TOKEN_ID"])),
+        api_token_secret=dict(type="str", no_log=True, fallback=(env_fallback, ["PROXMOX_TOKEN_SECRET"])),
+        ca_path=dict(type="path", fallback=(env_fallback, ["PROXMOX_CA_PATH"])),
+        validate_certs=dict(type="bool", fallback=(env_fallback, ["PROXMOX_VALIDATE_CERTS"])),
+        api_timeout=dict(type="int", default=5, fallback=(env_fallback, ["PROXMOX_API_TIMEOUT"])),
     )
 
 
 def proxmox_to_ansible_bool(value):
-    '''Convert Proxmox representation of a boolean to be ansible-friendly'''
+    """Convert Proxmox representation of a boolean to be ansible-friendly"""
     return True if value == 1 else False
 
 
 def ansible_to_proxmox_bool(value):
-    '''Convert Ansible representation of a boolean to be proxmox-friendly'''
+    """Convert Ansible representation of a boolean to be proxmox-friendly"""
     if value is None:
         return None
 
@@ -76,7 +54,7 @@ def ansible_to_proxmox_bool(value):
 
 
 def compare_list_of_dicts(existing_list, new_list, uid, params_to_ignore=None):
-    """ Compare 2 list of dicts
+    """Compare 2 list of dicts
     Use case - for firewall rules we will be getting a list of rules from user.
     We want to filter out which rules needs to be updated and which rules are completely new and needs to be created
 
@@ -115,22 +93,25 @@ def compare_list_of_dicts(existing_list, new_list, uid, params_to_ignore=None):
         # If existing rule param value doesn't match new rule param OR
         # If existing rule has a param that is not present in new rule except for params in params_to_ignore
         for existing_rule_param, existing_parm_value in existing_list[uid].items():
-            if (existing_rule_param not in params_to_ignore and
-                    new_list[uid].get(existing_rule_param) != existing_parm_value):
+            if (
+                existing_rule_param not in params_to_ignore
+                and new_list[uid].get(existing_rule_param) != existing_parm_value
+            ):
                 items_to_update.append(new_list[uid])
 
     return items_to_create, items_to_update
 
 
-class ProxmoxAnsible(object):
+class ProxmoxAnsible:
     """Base class for Proxmox modules"""
-    TASK_TIMED_OUT = 'timeout expired'
+
+    TASK_TIMED_OUT = "timeout expired"
 
     def __init__(self, module):
         if not HAS_PROXMOXER:
-            module.fail_json(msg=missing_required_lib('proxmoxer'), exception=PROXMOXER_IMP_ERR)
-        if proxmoxer_version < LooseVersion('2.0'):
-            module.fail_json(f'Requires proxmoxer 2.0 or newer; found version {proxmoxer_version}')
+            module.fail_json(msg=missing_required_lib("proxmoxer"), exception=PROXMOXER_IMP_ERR)
+        if proxmoxer_version < LooseVersion("2.0"):
+            module.fail_json(f"Requires proxmoxer 2.0 or newer; found version {proxmoxer_version}")
 
         self.module = module
         self.proxmoxer_version = proxmoxer_version
@@ -139,88 +120,89 @@ class ProxmoxAnsible(object):
         try:
             self.proxmox_api.version.get()
         except Exception as e:
-            module.fail_json(msg='%s' % e, exception=traceback.format_exc())
+            module.fail_json(msg="%s" % e, exception=traceback.format_exc())
 
     def _connect(self):
-        api_host = self.module.params['api_host']
-        api_port = self.module.params['api_port']
-        api_user = self.module.params['api_user']
-        api_password = self.module.params['api_password']
-        api_token_id = self.module.params['api_token_id']
-        api_token_secret = self.module.params['api_token_secret']
-        if self.module.params['validate_certs'] is None:
-            self.module.deprecate("The connection setting `validate_certs` was not provided and "
-                                  "defaults to `false`. This default will change to `true` in"
-                                  "in community.proxmox 2.0.0.",
-                                  version="2.0.0",
-                                  collection_name="community.proxmox",
-                                  )
-            self.module.params['validate_certs'] = False
+        api_host = self.module.params["api_host"]
+        api_port = self.module.params["api_port"]
+        api_user = self.module.params["api_user"]
+        api_password = self.module.params["api_password"]
+        api_token_id = self.module.params["api_token_id"]
+        api_token_secret = self.module.params["api_token_secret"]
+        if self.module.params["validate_certs"] is None:
+            self.module.deprecate(
+                "The connection setting `validate_certs` was not provided and "
+                "defaults to `false`. This default will change to `true` in"
+                "in community.proxmox 2.0.0.",
+                version="2.0.0",
+                collection_name="community.proxmox",
+            )
+            self.module.params["validate_certs"] = False
         # Only push the cert path as a string to proxmoxer, if validation is required
         # verify_ssl supports True, False or Path as values
-        if self.module.params["ca_path"] and self.module.params['validate_certs']:
+        if self.module.params["ca_path"] and self.module.params["validate_certs"]:
             validate_certs = self.module.params["ca_path"]
         else:
-            validate_certs = self.module.params['validate_certs']
-        validate_certs = self.module.params['validate_certs']
-        api_timeout = self.module.params['api_timeout']
-        auth_args = {'user': api_user}
+            validate_certs = self.module.params["validate_certs"]
+        validate_certs = self.module.params["validate_certs"]
+        api_timeout = self.module.params["api_timeout"]
+        auth_args = {"user": api_user}
 
         if api_port:
-            auth_args['port'] = api_port
+            auth_args["port"] = api_port
 
         if api_password:
-            auth_args['password'] = api_password
+            auth_args["password"] = api_password
         else:
-            auth_args['token_name'] = api_token_id
-            auth_args['token_value'] = api_token_secret
+            auth_args["token_name"] = api_token_id
+            auth_args["token_value"] = api_token_secret
 
         try:
             return ProxmoxAPI(api_host, timeout=api_timeout, verify_ssl=validate_certs, **auth_args)
         except Exception as e:
-            self.module.fail_json(msg='%s' % e, exception=traceback.format_exc())
+            self.module.fail_json(msg="%s" % e, exception=traceback.format_exc())
 
     def version(self):
         try:
             apiversion = self.proxmox_api.version.get()
-            return LooseVersion(apiversion['version'])
+            return LooseVersion(apiversion["version"])
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve Proxmox VE version: %s' % e)
+            self.module.fail_json(msg="Unable to retrieve Proxmox VE version: %s" % e)
 
     def get_node(self, node):
         try:
-            nodes = [n for n in self.proxmox_api.nodes.get() if n['node'] == node]
+            nodes = [n for n in self.proxmox_api.nodes.get() if n["node"] == node]
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve Proxmox VE node: %s' % e)
+            self.module.fail_json(msg="Unable to retrieve Proxmox VE node: %s" % e)
         return nodes[0] if nodes else None
 
     def get_nextvmid(self):
         try:
             return self.proxmox_api.cluster.nextid.get()
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve next free vmid: %s' % e)
+            self.module.fail_json(msg="Unable to retrieve next free vmid: %s" % e)
 
     def get_vmid(self, name, ignore_missing=False, choose_first_if_multiple=False):
         try:
-            vms = [vm['vmid'] for vm in self.proxmox_api.cluster.resources.get(type='vm') if vm.get('name') == name]
+            vms = [vm["vmid"] for vm in self.proxmox_api.cluster.resources.get(type="vm") if vm.get("name") == name]
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve list of VMs filtered by name %s: %s' % (name, e))
+            self.module.fail_json(msg="Unable to retrieve list of VMs filtered by name %s: %s" % (name, e))
 
         if not vms:
             if ignore_missing:
                 return None
 
-            self.module.fail_json(msg='No VM with name %s found' % name)
+            self.module.fail_json(msg="No VM with name %s found" % name)
         elif len(vms) > 1 and not choose_first_if_multiple:
-            self.module.fail_json(msg='Multiple VMs with name %s found, provide vmid instead' % name)
+            self.module.fail_json(msg="Multiple VMs with name %s found, provide vmid instead" % name)
 
         return vms[0]
 
     def get_vm(self, vmid, ignore_missing=False):
         try:
-            vms = [vm for vm in self.proxmox_api.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
+            vms = [vm for vm in self.proxmox_api.cluster.resources.get(type="vm") if vm["vmid"] == int(vmid)]
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve list of VMs filtered by vmid %s: %s' % (vmid, e))
+            self.module.fail_json(msg="Unable to retrieve list of VMs filtered by vmid %s: %s" % (vmid, e))
 
         if vms:
             return vms[0]
@@ -228,24 +210,23 @@ class ProxmoxAnsible(object):
             if ignore_missing:
                 return None
 
-            self.module.fail_json(msg='VM with vmid %s does not exist in cluster' % vmid)
+            self.module.fail_json(msg="VM with vmid %s does not exist in cluster" % vmid)
 
     def api_task_ok(self, node, taskid):
         try:
             status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            exitstatus = to_native(status.get('exitstatus') or '')
-            return status['status'] == 'stopped' and (exitstatus == 'OK' or exitstatus.startswith('WARN'))
+            exitstatus = to_native(status.get("exitstatus") or "")
+            return status["status"] == "stopped" and (exitstatus == "OK" or exitstatus.startswith("WARN"))
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve API task ID from node %s: %s' % (node, e))
+            self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node, e))
 
     def api_task_failed(self, node, taskid):
-        """ Explicitly check if the task stops but exits with a failed status
-        """
+        """Explicitly check if the task stops but exits with a failed status"""
         try:
             status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
-            return status['status'] == 'stopped' and status['exitstatus'] != 'OK'
+            return status["status"] == "stopped" and status["exitstatus"] != "OK"
         except Exception as e:
-            self.module.fail_json(msg='Unable to retrieve API task ID from node %s: %s' % (node, e))
+            self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node, e))
 
     def api_task_complete(self, node_name, task_id, timeout):
         """Wait until the task stops or times out.
@@ -260,13 +241,13 @@ class ProxmoxAnsible(object):
             try:
                 status = self.proxmox_api.nodes(node_name).tasks(task_id).status.get()
             except Exception as e:
-                self.module.fail_json(msg='Unable to retrieve API task ID from node %s: %s' % (node_name, e))
+                self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node_name, e))
 
-            if status['status'] == 'stopped':
-                if status['exitstatus'] == 'OK':
+            if status["status"] == "stopped":
+                if status["exitstatus"] == "OK":
                     return True, None
                 else:
-                    return False, status['exitstatus']
+                    return False, status["exitstatus"]
             else:
                 timeout -= 1
                 if timeout <= 0:
@@ -297,14 +278,8 @@ class ProxmoxAnsible(object):
 
     def get_storage_content(self, node, storage, content=None, vmid=None):
         try:
-            return (
-                self.proxmox_api.nodes(node)
-                .storage(storage)
-                .content()
-                .get(content=content, vmid=vmid)
-            )
+            return self.proxmox_api.nodes(node).storage(storage).content().get(content=content, vmid=vmid)
         except Exception as e:
             self.module.fail_json(
-                msg="Unable to list content on %s, %s for %s and %s: %s"
-                % (node, storage, content, vmid, e)
+                msg="Unable to list content on %s, %s for %s and %s: %s" % (node, storage, content, vmid, e)
             )

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -73,7 +73,8 @@ def ansible_to_proxmox_bool(value):
 
 
 def compare_list_of_dicts(existing_list, new_list, uid, params_to_ignore=None):
-    """Compare 2 list of dicts
+    """Compare 2 list of dicts.
+
     Use case - for firewall rules we will be getting a list of rules from user.
     We want to filter out which rules needs to be updated and which rules are completely new and needs to be created
 

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -51,8 +51,11 @@ def proxmox_auth_argument_spec():
                               no_log=True,
                               fallback=(env_fallback, ['PROXMOX_TOKEN_SECRET'])
                               ),
+        ca_path=dict(type='str',
+                            fallback=(env_fallback, ['PROXMOX_CA_PATH'])
+                            ),
         validate_certs=dict(type='bool',
-                            default=False,
+                            default=True,
                             fallback=(env_fallback, ['PROXMOX_VALIDATE_CERTS'])
                             ),
     )
@@ -147,7 +150,10 @@ class ProxmoxAnsible(object):
         api_password = self.module.params['api_password']
         api_token_id = self.module.params['api_token_id']
         api_token_secret = self.module.params['api_token_secret']
-        validate_certs = self.module.params['validate_certs']
+        if self.module.params["ca_path"]:
+            validate_certs = self.module.params["ca_path"]
+        else:
+            validate_certs = self.module.params['validate_certs']
 
         if 'timeout' in self.module.params:
             timeout = self.module.params['timeout']

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -50,7 +50,7 @@ def proxmox_auth_argument_spec():
                               no_log=True,
                               fallback=(env_fallback, ['PROXMOX_TOKEN_SECRET'])
                               ),
-        ca_path=dict(type='str',fallback=(env_fallback, ['PROXMOX_CA_PATH'])),
+        ca_path=dict(type='path',fallback=(env_fallback, ['PROXMOX_CA_PATH'])),
         validate_certs=dict(type='bool',fallback=(env_fallback, ['PROXMOX_VALIDATE_CERTS'])),
         api_timeout=dict(type='int',
                          default=5,

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -150,7 +150,7 @@ class ProxmoxAnsible(object):
         api_password = self.module.params['api_password']
         api_token_id = self.module.params['api_token_id']
         api_token_secret = self.module.params['api_token_secret']
-        if self.module.params["ca_path"]:
+        if self.module.params["ca_path"] and self.module.params['validate_certs']:
             validate_certs = self.module.params["ca_path"]
         else:
             validate_certs = self.module.params['validate_certs']

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -51,13 +51,8 @@ def proxmox_auth_argument_spec():
                               no_log=True,
                               fallback=(env_fallback, ['PROXMOX_TOKEN_SECRET'])
                               ),
-        ca_path=dict(type='str',
-                            fallback=(env_fallback, ['PROXMOX_CA_PATH'])
-                            ),
-        validate_certs=dict(type='bool',
-                            default=True,
-                            fallback=(env_fallback, ['PROXMOX_VALIDATE_CERTS'])
-                            ),
+        ca_path=dict(type='str',fallback=(env_fallback, ['PROXMOX_CA_PATH'])),
+        validate_certs=dict(type='bool',fallback=(env_fallback, ['PROXMOX_VALIDATE_CERTS'])),
     )
 
 
@@ -150,6 +145,14 @@ class ProxmoxAnsible(object):
         api_password = self.module.params['api_password']
         api_token_id = self.module.params['api_token_id']
         api_token_secret = self.module.params['api_token_secret']
+        if self.module.params['validate_certs'] is None:
+            self.module.deprecate("The connection setting `validate_certs` was not provided and "
+                                  "defaults to true. This default will change to `false` in"
+                                  "in community.proxmox 2.0.0.",
+                                  version="2.0.0",
+                                  collection_name="community.proxmox",
+                                  )
+            self.module.params['validate_certs'] = False
         if self.module.params["ca_path"] and self.module.params['validate_certs']:
             validate_certs = self.module.params["ca_path"]
         else:

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -24,6 +24,12 @@ from ansible_collections.community.proxmox.plugins.module_utils.version import L
 
 
 def proxmox_auth_argument_spec():
+    """
+    Returns the authentication argument specification for Proxmox API modules.
+
+    Returns:
+        dict[str, dict]: Parameter names mapped to their configuration dictionaries.
+    """
     return dict(
         api_host=dict(type="str", required=True, fallback=(env_fallback, ["PROXMOX_HOST"])),
         api_port=dict(type="int", fallback=(env_fallback, ["PROXMOX_PORT"])),
@@ -37,36 +43,55 @@ def proxmox_auth_argument_spec():
     )
 
 
-def proxmox_to_ansible_bool(value):
-    """Convert Proxmox representation of a boolean to be ansible-friendly"""
-    return True if value == 1 else False
+def proxmox_to_ansible_bool(value):  # noqa: SIM210
+    """Convert Proxmox representation of a boolean to be ansible-friendly.
+
+    Args:
+        value(int): The value which needs to be converted to a boolean.
+
+    Returns:
+        bool: True if value = `1`, False for everything else including non-integers.
+    """
+    if isinstance(value, int) and value == 1:
+        return True
+    return False
 
 
 def ansible_to_proxmox_bool(value):
-    """Convert Ansible representation of a boolean to be proxmox-friendly"""
+    """
+    Convert Ansible representation of a boolean to be proxmox-friendly.
+
+    Returns:
+        `None` when value is`None`, `1` for `True` and `0` for `False`
+    """
     if value is None:
         return None
 
     if not isinstance(value, bool):
-        raise ValueError("%s must be of type bool not %s" % (value, type(value)))
+        raise ValueError(f"{value} must be of type bool not {type(value)}")
 
     return 1 if value else 0
 
 
 def compare_list_of_dicts(existing_list, new_list, uid, params_to_ignore=None):
-    """Compare 2 list of dicts
+    """
+    Compare two lists of dicts.
     Use case - for firewall rules we will be getting a list of rules from user.
     We want to filter out which rules needs to be updated and which rules are completely new and needs to be created
 
-    :param existing_list: Existing values example - list of existing rules
-    :param new_list: New values example - list of rules passed to module
-    :param uid: unique identifier in dict. It should always be present in both lists - in case of firewall rules it's pos
-    :param params_to_ignore:  list of params we want to ignore which are present in existing_list's dict.
-                            In case of firewall rules we want to ignore ['digest', 'ipversion']
+    Args:
+        existing_list(list): Existing values example - list of existing rules
+        new_list(list): New values example - list of rules passed to module
+        uid(str): unique identifier in dict.
+            It should always be present in both lists - in case of firewall rules it's `pos`.
+        params_to_ignore(list): list of params we want to ignore, which are present in existing_list's dict.
+            In case of firewall rules we want to ignore `['digest', 'ipversion']`.
 
-    :return: returns 2 list items 1st is the list of items which are completely new and needs to be created
+    Returns:
+         tuple(list, list): 2 lists: 1st is the list of items which are completely new and needs to be created
             2nd is a list of items which needs to be updated
     """
+
     if params_to_ignore is None:
         params_to_ignore = list()
     items_to_update = []
@@ -84,26 +109,26 @@ def compare_list_of_dicts(existing_list, new_list, uid, params_to_ignore=None):
     missing_uids = set(new_list.keys()) - set(existing_list.keys())
     items_to_create = [new_list[uid] for uid in missing_uids]
 
-    for uid in common_uids:
+    for c_uid in common_uids:
         # If new rule has a parameter that is not present in existing rule we need to update
-        if set(new_list[uid].keys()) - set(existing_list[uid].keys()) != set():
-            items_to_update.append(new_list[uid])
+        if set(new_list[c_uid].keys()) - set(existing_list[c_uid].keys()) != set():
+            items_to_update.append(new_list[c_uid])
             continue
 
         # If existing rule param value doesn't match new rule param OR
         # If existing rule has a param that is not present in new rule except for params in params_to_ignore
-        for existing_rule_param, existing_parm_value in existing_list[uid].items():
+        for existing_rule_param, existing_parm_value in existing_list[c_uid].items():
             if (
                 existing_rule_param not in params_to_ignore
-                and new_list[uid].get(existing_rule_param) != existing_parm_value
+                and new_list[c_uid].get(existing_rule_param) != existing_parm_value
             ):
-                items_to_update.append(new_list[uid])
+                items_to_update.append(new_list[c_uid])
 
     return items_to_create, items_to_update
 
 
 class ProxmoxAnsible:
-    """Base class for Proxmox modules"""
+    """Base class for Proxmox modules."""
 
     TASK_TIMED_OUT = "timeout expired"
 
@@ -120,7 +145,7 @@ class ProxmoxAnsible:
         try:
             self.proxmox_api.version.get()
         except Exception as e:
-            module.fail_json(msg="%s" % e, exception=traceback.format_exc())
+            module.fail_json(msg=f"{e}", exception=traceback.format_exc())
 
     def _connect(self):
         api_host = self.module.params["api_host"]
@@ -160,41 +185,73 @@ class ProxmoxAnsible:
         try:
             return ProxmoxAPI(api_host, timeout=api_timeout, verify_ssl=validate_certs, **auth_args)
         except Exception as e:
-            self.module.fail_json(msg="%s" % e, exception=traceback.format_exc())
+            self.module.fail_json(msg=f"{e}", exception=traceback.format_exc())
 
     def version(self):
+        """
+        Queries the proxmox api for its current version.
+
+        Returns:
+            int: Major release of the Proxmox VE host.
+        """
         try:
             apiversion = self.proxmox_api.version.get()
             return LooseVersion(apiversion["version"])
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve Proxmox VE version: %s" % e)
+            self.module.fail_json(msg=f"Unable to retrieve Proxmox VE version: {e}")
 
     def get_node(self, node):
+        """
+        Filters all known PVE nodes for the given node name.
+
+        Args:
+            node(str): The name of the node.
+
+        Returns:
+            dict | None: The node information provided by the api path GET /nodes.
+        """
         try:
             nodes = [n for n in self.proxmox_api.nodes.get() if n["node"] == node]
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve Proxmox VE node: %s" % e)
+            self.module.fail_json(msg=f"Unable to retrieve Proxmox VE node: {e}")
         return nodes[0] if nodes else None
 
     def get_nextvmid(self):
+        """
+        Queries the PVE api for the next vmid.
+
+        Returns:
+            int: The next vmid.
+        """
         try:
             return self.proxmox_api.cluster.nextid.get()
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve next free vmid: %s" % e)
+            self.module.fail_json(msg=f"Unable to retrieve next free vmid: {e}")
 
     def get_vmid(self, name, ignore_missing=False, choose_first_if_multiple=False):
+        """
+        Searches the PVE vms for a vms with the given name.
+
+        Args:
+            name(str): The name to filter the api output to.
+            ignore_missing (bool): Don't fail the task if no vm could be found.
+            choose_first_if_multiple (bool): Don't fail the task if several names match.
+
+        Returns:
+            int | None : The matching vmid or None, when no name matched.
+        """
         try:
             vms = [vm["vmid"] for vm in self.proxmox_api.cluster.resources.get(type="vm") if vm.get("name") == name]
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve list of VMs filtered by name %s: %s" % (name, e))
+            self.module.fail_json(msg=f"Unable to retrieve list of VMs filtered by name {name}: {e}")
 
         if not vms:
             if ignore_missing:
                 return None
 
-            self.module.fail_json(msg="No VM with name %s found" % name)
+            self.module.fail_json(msg=f"No VM with name {name}f found")
         elif len(vms) > 1 and not choose_first_if_multiple:
-            self.module.fail_json(msg="Multiple VMs with name %s found, provide vmid instead" % name)
+            self.module.fail_json(msg=f"Multiple VMs with name {name} found, provide vmid instead")
 
         return vms[0]
 
@@ -202,7 +259,7 @@ class ProxmoxAnsible:
         try:
             vms = [vm for vm in self.proxmox_api.cluster.resources.get(type="vm") if vm["vmid"] == int(vmid)]
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve list of VMs filtered by vmid %s: %s" % (vmid, e))
+            self.module.fail_json(msg=f"Unable to retrieve list of VMs filtered by vmid {vmid}: {e}")
 
         if vms:
             return vms[0]
@@ -210,7 +267,7 @@ class ProxmoxAnsible:
             if ignore_missing:
                 return None
 
-            self.module.fail_json(msg="VM with vmid %s does not exist in cluster" % vmid)
+            self.module.fail_json(msg=f"VM with vmid {vmid} does not exist in cluster")
 
     def api_task_ok(self, node, taskid):
         try:
@@ -218,7 +275,7 @@ class ProxmoxAnsible:
             exitstatus = to_native(status.get("exitstatus") or "")
             return status["status"] == "stopped" and (exitstatus == "OK" or exitstatus.startswith("WARN"))
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node, e))
+            self.module.fail_json(msg=f"Unable to retrieve API task ID from node {node}: {e}")
 
     def api_task_failed(self, node, taskid):
         """Explicitly check if the task stops but exits with a failed status"""
@@ -226,7 +283,7 @@ class ProxmoxAnsible:
             status = self.proxmox_api.nodes(node).tasks(taskid).status.get()
             return status["status"] == "stopped" and status["exitstatus"] != "OK"
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node, e))
+            self.module.fail_json(msg=f"Unable to retrieve API task ID from node {node}: {e}")
 
     def api_task_complete(self, node_name, task_id, timeout):
         """Wait until the task stops or times out.
@@ -241,7 +298,7 @@ class ProxmoxAnsible:
             try:
                 status = self.proxmox_api.nodes(node_name).tasks(task_id).status.get()
             except Exception as e:
-                self.module.fail_json(msg="Unable to retrieve API task ID from node %s: %s" % (node_name, e))
+                self.module.fail_json(msg=f"Unable to retrieve API task ID from node {node_name}: {e}")
 
             if status["status"] == "stopped":
                 if status["exitstatus"] == "OK":
@@ -255,7 +312,7 @@ class ProxmoxAnsible:
                 sleep(1)
 
     def get_pool(self, poolid):
-        """Retrieve pool information
+        """Retrieve pool information.
 
         :param poolid: str - name of the pool
         :return: dict - pool information
@@ -263,10 +320,10 @@ class ProxmoxAnsible:
         try:
             return self.proxmox_api.pools(poolid).get()
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve pool %s information: %s" % (poolid, e))
+            self.module.fail_json(msg=f"Unable to retrieve pool {poolid} information: {e}")
 
     def get_storages(self, type):
-        """Retrieve storages information
+        """Retrieve storages information.
 
         :param type: str, optional - type of storages
         :return: list of dicts - array of storages
@@ -274,12 +331,10 @@ class ProxmoxAnsible:
         try:
             return self.proxmox_api.storage.get(type=type)
         except Exception as e:
-            self.module.fail_json(msg="Unable to retrieve storages information with type %s: %s" % (type, e))
+            self.module.fail_json(msg=f"Unable to retrieve storages information with type {type}: {e}")
 
     def get_storage_content(self, node, storage, content=None, vmid=None):
         try:
             return self.proxmox_api.nodes(node).storage(storage).content().get(content=content, vmid=vmid)
         except Exception as e:
-            self.module.fail_json(
-                msg="Unable to list content on %s, %s for %s and %s: %s" % (node, storage, content, vmid, e)
-            )
+            self.module.fail_json(msg=f"Unable to list content on {node}, {storage} for {content} and {vmid}: {e}")

--- a/plugins/modules/proxmox_storage_info.py
+++ b/plugins/modules/proxmox_storage_info.py
@@ -125,8 +125,8 @@ class ProxmoxStorageInfoAnsible(ProxmoxAnsible):
             self.module.fail_json(msg="Storage '%s' does not exist" % storage)
         return ProxmoxStorage(storage)
 
-    def get_storages(self, type=None):
-        storages = self.proxmox_api.storage.get(type=type)
+    def get_storages(self, storagetype=None):
+        storages = self.proxmox_api.storage.get(type=storagetype)
         storages = [ProxmoxStorage(storage) for storage in storages]
         return storages
 
@@ -178,7 +178,7 @@ def main():
     if storage:
         storages = [proxmox.get_storage(storage)]
     else:
-        storages = proxmox.get_storages(type=storagetype)
+        storages = proxmox.get_storages(storagetype=storagetype)
     result["proxmox_storages"] = [storage.storage for storage in storages]
 
     module.exit_json(**result)

--- a/plugins/modules/proxmox_storage_info.py
+++ b/plugins/modules/proxmox_storage_info.py
@@ -122,7 +122,7 @@ class ProxmoxStorageInfoAnsible(ProxmoxAnsible):
         try:
             storage = self.proxmox_api.storage.get(storage)
         except Exception:
-            self.module.fail_json(msg="Storage '%s' does not exist" % storage)
+            self.module.fail_json(msg=f"Storage {storage} does not exist")
         return ProxmoxStorage(storage)
 
     def get_storages(self, storagetype=None):


### PR DESCRIPTION
This PR adds a global option to specify a ca-certificate used for tls-validation. It uses the `verify` option of [requests](https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification) to specify a certificate, which should be used for tls validation. 

Since proxmoxer passes the `verify_ssl` kwarg down to requests `verify`, passing the certificate down to proxmoxer will in turn lead to successfull connections with requests.

I am not sure if the configuration title of `ca_path` is the best choice. :shrug: 

This change might be breaking though, if we actually really change the default tls validation from `False` to  `True`. I think this would be wise from a security point of view, but it would definetely impact existing users and playbooks, since most will not use valid certificates on their proxmox-apis.