### PR TITLE
Improve inventory speed

### DIFF
--- a/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
+++ b/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
@@ -2,6 +2,6 @@
 minor_changes:
   - inventory plugin - add exclude_vms option (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - add facts_concurrency option for concurrent LXC/QEMU fact gathering (https://github.com/ansible-collections/community.proxmox/pull/257).
-  - inventory plugin - add request_timeout option for Proxmox API requests and keep hosts in inventory when optional LXC/QEMU fact gathering fails (https://github.com/ansible-collections/community.proxmox/pull/257).
+  - inventory plugin - add api_timeout option for Proxmox API requests and keep hosts in inventory when optional LXC/QEMU fact gathering fails (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - fetch nodes from /api2/json/cluster/status instead of /api2/json/nodes (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - fetch QEMU and LXC inventory records from /api2/json/cluster/resources?type=vm instead of querying every online node (https://github.com/ansible-collections/community.proxmox/pull/257).

--- a/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
+++ b/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - inventory plugin - add exclude_vms option (https://github.com/ansible-collections/community.proxmox/pull/257).
+  - inventory plugin - add facts_concurrency option for concurrent LXC/QEMU fact gathering (https://github.com/ansible-collections/community.proxmox/pull/257).
+  - inventory plugin - fetch nodes from /api2/json/cluster/status instead of /api2/json/nodes (https://github.com/ansible-collections/community.proxmox/pull/257).
+  - inventory plugin - fetch QEMU and LXC inventory records from /api2/json/cluster/resources?type=vm instead of querying every online node (https://github.com/ansible-collections/community.proxmox/pull/257).

--- a/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
+++ b/changelogs/fragments/257-inventory_speedup_exclude_vms.yml
@@ -2,5 +2,6 @@
 minor_changes:
   - inventory plugin - add exclude_vms option (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - add facts_concurrency option for concurrent LXC/QEMU fact gathering (https://github.com/ansible-collections/community.proxmox/pull/257).
+  - inventory plugin - add request_timeout option for Proxmox API requests and keep hosts in inventory when optional LXC/QEMU fact gathering fails (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - fetch nodes from /api2/json/cluster/status instead of /api2/json/nodes (https://github.com/ansible-collections/community.proxmox/pull/257).
   - inventory plugin - fetch QEMU and LXC inventory records from /api2/json/cluster/resources?type=vm instead of querying every online node (https://github.com/ansible-collections/community.proxmox/pull/257).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -91,6 +91,14 @@ DOCUMENTATION = """
             but its actual state will be paused. See O(qemu_extended_statuses) for how to retrieve the real status.
         default: false
         type: bool
+      facts_concurrency:
+        description:
+          - Number of concurrent workers to use when gathering LXC/QEMU configuration facts.
+          - Only applies when O(want_facts) is set to V(true).
+          - Higher values can reduce inventory runtime over slow links, but will increase load on the Proxmox API.
+          - Set to V(1) to gather facts serially.
+        default: 1
+        type: int
       want_post_filter_facts:
         description:
         - Whether to collect facts after host filtering (in contrast to pull all facts of all hosts before filtering as with O(want_facts) set to V(true)).
@@ -113,6 +121,10 @@ DOCUMENTATION = """
         default: false
       exclude_nodes:
         description: Exclude proxmox nodes and the nodes-group from the inventory output.
+        type: bool
+        default: false
+      exclude_vms:
+        description: Exclude LXC containers and QEMU virtual machines from the inventory output.
         type: bool
         default: false
       filters:
@@ -209,10 +221,11 @@ want_proxmox_nodes_ansible_host: true
 
 """
 
-import itertools
 import re
 from collections.abc import MutableMapping
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from sys import version as python_version
+from threading import Lock, local
 from urllib.parse import urlencode
 
 from ansible.errors import AnsibleError
@@ -247,9 +260,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # from config
         self.proxmox_url = None
 
-        self.session = None
+        self._thread_local = local()
+        self._results_lock = Lock()
         self.cache_key = None
         self.use_cache = None
+        self.facts_concurrency = 1
 
     def verify_file(self, path):
         valid = False
@@ -261,13 +276,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return valid
 
     def _get_session(self):
-        if not self.session:
-            self.session = requests.session()
-            self.session.headers.update(
+        session = getattr(self._thread_local, "session", None)
+        if session is None:
+            session = requests.session()
+            session.headers.update(
                 {"User-Agent": f"ansible {ansible_version} Python {python_version.split(' ', 1)[0]}"}
             )
-            self.session.verify = self.get_option("validate_certs")
-        return self.session
+            session.verify = self.get_option("validate_certs")
+            self._thread_local.session = session
+        return session
 
     def _get_auth(self):
         if self.proxmox_password:
@@ -329,50 +346,39 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         data = data + json["data"]
                     break
 
-        self._results[url] = data
+        with self._results_lock:
+            self._results[url] = data
         return make_unsafe(data)
 
     def _get_nodes(self):
-        return self._get_json(f"{self.proxmox_url}/api2/json/nodes")
+        cluster_status = self._get_json(f"{self.proxmox_url}/api2/json/cluster/status")
+        return [item for item in cluster_status if item["type"] == "node"]
 
     def _get_pools(self):
         return self._get_json(f"{self.proxmox_url}/api2/json/pools")
 
-    def _get_lxc_per_node(self, node):
-        return self._get_json(f"{self.proxmox_url}/api2/json/nodes/{node}/lxc")
+    def _get_vms(self):
+        return self._get_json(f"{self.proxmox_url}/api2/json/cluster/resources?type=vm")
 
-    def _get_qemu_per_node(self, node):
-        return self._get_json(f"{self.proxmox_url}/api2/json/nodes/{node}/qemu")
+    def _get_vms_by_node(self):
+        vms_by_node = {"qemu": {}, "lxc": {}}
+
+        if self.exclude_vms:
+            return vms_by_node
+
+        for item in self._get_vms():
+            ittype = item.get("type")
+            if ittype not in vms_by_node or "node" not in item:
+                continue
+
+            node_items = vms_by_node[ittype].setdefault(item["node"], [])
+            node_items.append(item)
+
+        return vms_by_node
 
     def _get_members_per_pool(self, pool):
         ret = self._get_json(f"{self.proxmox_url}/api2/json/pools/{pool}")
         return ret["members"]
-
-    def _get_node_ip(self, node):
-        ret = self._get_json(f"{self.proxmox_url}/api2/json/nodes/{node}/network")
-
-        # sort interface by iface name to make selection as stable as possible
-        ret.sort(key=lambda x: x["iface"])
-
-        for iface in ret:
-            try:
-                # only process interfaces adhering to these rules
-                if "active" not in iface:
-                    self.display.vvv(f"Interface {iface['iface']} on node {node} does not have an active state")
-                    continue
-                if "address" not in iface:
-                    self.display.vvv(f"Interface {iface['iface']} on node {node} does not have an address")
-                    continue
-                if "gateway" not in iface:
-                    self.display.vvv(f"Interface {iface['iface']} on node {node} does not have a gateway")
-                    continue
-                self.display.vv(
-                    f"Using interface {iface['iface']} on node {node} with address {iface['address']} as node ip for ansible_host"
-                )
-                return iface["address"]
-            except Exception:
-                continue
-        return None
 
     def _get_lxc_interfaces(self, properties, node, vmid):
         status_key = self._fact("status")
@@ -515,6 +521,39 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if ittype == "lxc":
             self._get_lxc_interfaces(properties, node, vmid)
 
+    def _get_guest_facts_for_item(self, node, ittype, item):
+        display.vvvv(f"Gathering Proxmox guest facts for {node}/{ittype}/{item['vmid']} ({item['name']})")
+        properties = {}
+        self._get_guest_facts(properties, node, item["vmid"], ittype, item["name"])
+        return node, ittype, item["vmid"], properties
+
+    def _get_guest_facts_by_item(self, items):
+        guest_facts_by_item = {}
+
+        if not self.get_option("want_facts") or not items:
+            return guest_facts_by_item
+
+        display.vvv(
+            f"Gathering Proxmox guest facts for {len(items)} guests with {self.facts_concurrency} workers"
+        )
+
+        if self.facts_concurrency == 1:
+            for node, ittype, item in items:
+                result_node, result_ittype, vmid, properties = self._get_guest_facts_for_item(node, ittype, item)
+                guest_facts_by_item[(result_node, result_ittype, vmid)] = properties
+            return guest_facts_by_item
+
+        with ThreadPoolExecutor(max_workers=self.facts_concurrency) as executor:
+            futures = [
+                executor.submit(self._get_guest_facts_for_item, node, ittype, item)
+                for node, ittype, item in items
+            ]
+            for future in as_completed(futures):
+                node, ittype, vmid, properties = future.result()
+                guest_facts_by_item[(node, ittype, vmid)] = properties
+
+        return guest_facts_by_item
+
     def to_safe(self, word):
         """Converts 'bad' characters in a string to underscores so they can be used as Ansible groups
         #> ProxmoxInventory.to_safe("foo-bar baz")
@@ -556,7 +595,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self._add_host_to_composed_groups(self.get_option("groups"), variables, name, strict=self.strict)
         self._add_host_to_keyed_groups(self.get_option("keyed_groups"), variables, name, strict=self.strict)
 
-    def _handle_item(self, node, ittype, item):
+    def _handle_item(self, node, ittype, item, guest_facts=None):
         """Handle an item from the list of LXC containers and Qemu VM. The
         return value will be either None if the item was skipped or the name of
         the item if it was added to the inventory."""
@@ -578,7 +617,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # get status, config and snapshots if want_facts == True
         want_facts = self.get_option("want_facts")
         if want_facts:
-            self._get_guest_facts(properties, node, vmid, ittype, name)
+            if guest_facts is not None:
+                properties.update(guest_facts)
+            else:
+                self._get_guest_facts(properties, node, vmid, ittype, name)
 
         # ensure the host satisfies filters
         if not self._can_add_host(name, properties):
@@ -603,6 +645,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if item_status == "running" and want_facts and ittype == "qemu" and self.get_option("qemu_extended_statuses"):
             # get more details about the status of the qemu VM
             item_status = properties.get(self._fact("qmpstatus"), item_status)
+        self.inventory.add_group(self._group(f"all_{item_status}"))
         self.inventory.add_child(self._group(f"all_{item_status}"), name)
 
         return name
@@ -637,45 +680,44 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         want_proxmox_nodes_ansible_host = self.get_option("want_proxmox_nodes_ansible_host")
 
-        # gather vm's on nodes
+        # gather VMs on nodes
         self._get_auth()
         hosts = []
+        vms_by_node = self._get_vms_by_node()
+        vm_items = []
         for node in self._get_nodes():
-            if not node.get("node"):
-                continue
             if not self.exclude_nodes:
-                self.inventory.add_host(node["node"])
-            if node["type"] == "node" and not self.exclude_nodes:
-                self.inventory.add_child(nodes_group, node["node"])
+                self.inventory.add_host(node["name"])
+                self.inventory.add_child(nodes_group, node["name"])
+                if want_proxmox_nodes_ansible_host:
+                    self.inventory.set_variable(node["name"], "ansible_host", node["ip"])
 
-            if node["status"] == "offline":
+            if node["online"] != 1:
                 continue
-
-            # get node IP address
-            if want_proxmox_nodes_ansible_host and not self.exclude_nodes:
-                ip = self._get_node_ip(node["node"])
-                self.inventory.set_variable(node["node"], "ansible_host", ip)
 
             # Setting composite variables
             if not self.exclude_nodes:
-                variables = self.inventory.get_host(node["node"]).get_vars()
-                self._set_composite_vars(self.get_option("compose"), variables, node["node"], strict=self.strict)
+                variables = self.inventory.get_host(node["name"]).get_vars()
+                self._set_composite_vars(self.get_option("compose"), variables, node["name"], strict=self.strict)
 
-            # add LXC/Qemu groups for the node
-            for ittype in ("lxc", "qemu"):
-                node_type_group = self._group(f"{node['node']}_{ittype}")
-                self.inventory.add_group(node_type_group)
+            # add Qemu and LXC VMs for the node
+            if not self.exclude_vms:
+                for ittype in ("qemu", "lxc"):
+                    node_type_group = self._group(f"{node['name']}_{ittype}")
+                    self.inventory.add_group(node_type_group)
+                    for item in vms_by_node[ittype].get(node["name"], []):
+                        vm_items.append((node["name"], ittype, item))
 
-            # get LXC containers and Qemu VMs for this node
-            lxc_objects = zip(itertools.repeat("lxc"), self._get_lxc_per_node(node["node"]))
-            qemu_objects = zip(itertools.repeat("qemu"), self._get_qemu_per_node(node["node"]))
-            for ittype, item in itertools.chain(lxc_objects, qemu_objects):
-                name = self._handle_item(node["node"], ittype, item)
-                if name is not None:
-                    hosts.append(name)
+        guest_facts_by_item = self._get_guest_facts_by_item(vm_items)
+        for node, ittype, item in vm_items:
+            guest_facts = guest_facts_by_item.get((node, ittype, item["vmid"]))
+            name = self._handle_item(node, ittype, item, guest_facts=guest_facts)
+            if name is not None:
+                hosts.append(name)
 
         # gather vm's in pools
-        self._populate_pool_groups(hosts)
+        if not self.exclude_vms:
+            self._populate_pool_groups(hosts)
 
     def parse(self, inventory, loader, path, cache=True):
         if not HAS_REQUESTS:
@@ -701,8 +743,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if self.get_option("qemu_extended_statuses") and not self.get_option("want_facts"):
             raise AnsibleError("You must set want_facts to True if you want to use qemu_extended_statuses.")
+        if self.get_option("facts_concurrency") < 1:
+            raise AnsibleError("You must set facts_concurrency to 1 or greater.")
         # read rest of options
         self.exclude_nodes = self.get_option("exclude_nodes")
+        self.exclude_vms = self.get_option("exclude_vms")
+        self.facts_concurrency = self.get_option("facts_concurrency")
         self.cache_key = self.get_cache_key(path)
         self.use_cache = cache and self.get_option("cache")
         self.update_cache = not cache and self.get_option("cache")

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -245,6 +245,7 @@ from ansible_collections.community.proxmox.plugins.plugin_utils.unsafe import ma
 # 3rd party imports
 try:
     import requests
+    import urllib3
 
     if LooseVersion(requests.__version__) < LooseVersion("1.1.0"):
         raise ImportError
@@ -290,6 +291,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 {"User-Agent": f"ansible {ansible_version} Python {python_version.split(' ', 1)[0]}"}
             )
             session.verify = self.get_option("validate_certs")
+            if not session.verify:
+                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             self._thread_local.session = session
         return session
 
@@ -569,9 +572,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not self.get_option("want_facts") or not items:
             return guest_facts_by_item
 
-        display.vvv(
-            f"Gathering Proxmox guest facts for {len(items)} guests with {self.facts_concurrency} workers"
-        )
+        display.vvv(f"Gathering Proxmox guest facts for {len(items)} guests with {self.facts_concurrency} workers")
 
         if self.facts_concurrency == 1:
             for node, ittype, item in items:
@@ -582,8 +583,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         executor = ThreadPoolExecutor(max_workers=self.facts_concurrency)
         try:
             futures = [
-                executor.submit(self._get_guest_facts_for_item, node, ittype, item)
-                for node, ittype, item in items
+                executor.submit(self._get_guest_facts_for_item, node, ittype, item) for node, ittype, item in items
             ]
             for future in as_completed(futures):
                 node, ittype, vmid, properties = future.result()

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -99,11 +99,11 @@ DOCUMENTATION = """
           - Set to V(1) to gather facts serially.
         default: 1
         type: int
-      request_timeout:
+      api_timeout:
         description:
           - Timeout in seconds for Proxmox API requests.
           - The timeout is passed to the underlying HTTP client and applies to connection and socket read waits.
-        default: 30
+        default: 5
         type: int
       want_post_filter_facts:
         description:
@@ -272,7 +272,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.cache_key = None
         self.use_cache = None
         self.facts_concurrency = 1
-        self.request_timeout = 30
+        self.api_timeout = 5
 
     def verify_file(self, path):
         valid = False
@@ -303,7 +303,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             ret = a.post(
                 f"{self.proxmox_url}/api2/json/access/ticket",
                 data=credentials,
-                timeout=self.request_timeout,
+                timeout=self.api_timeout,
             )
             json = ret.json()
             self.headers = {
@@ -337,7 +337,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not has_data:
             s = self._get_session()
             while True:
-                ret = s.get(url, headers=self.headers, timeout=self.request_timeout)
+                ret = s.get(url, headers=self.headers, timeout=self.api_timeout)
                 if ignore_errors and ret.status_code in ignore_errors:
                     break
                 ret.raise_for_status()
@@ -793,13 +793,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise AnsibleError("You must set want_facts to True if you want to use qemu_extended_statuses.")
         if self.get_option("facts_concurrency") < 1:
             raise AnsibleError("You must set facts_concurrency to 1 or greater.")
-        if self.get_option("request_timeout") < 1:
-            raise AnsibleError("You must set request_timeout to 1 or greater.")
+        if self.get_option("api_timeout") < 1:
+            raise AnsibleError("You must set api_timeout to 1 or greater.")
         # read rest of options
         self.exclude_nodes = self.get_option("exclude_nodes")
         self.exclude_vms = self.get_option("exclude_vms")
         self.facts_concurrency = self.get_option("facts_concurrency")
-        self.request_timeout = self.get_option("request_timeout")
+        self.api_timeout = self.get_option("api_timeout")
         self.cache_key = self.get_cache_key(path)
         self.use_cache = cache and self.get_option("cache")
         self.update_cache = not cache and self.get_option("cache")

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -99,6 +99,12 @@ DOCUMENTATION = """
           - Set to V(1) to gather facts serially.
         default: 1
         type: int
+      request_timeout:
+        description:
+          - Timeout in seconds for Proxmox API requests.
+          - The timeout is passed to the underlying HTTP client and applies to connection and socket read waits.
+        default: 30
+        type: int
       want_post_filter_facts:
         description:
         - Whether to collect facts after host filtering (in contrast to pull all facts of all hosts before filtering as with O(want_facts) set to V(true)).
@@ -265,6 +271,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.cache_key = None
         self.use_cache = None
         self.facts_concurrency = 1
+        self.request_timeout = 30
 
     def verify_file(self, path):
         valid = False
@@ -290,7 +297,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if self.proxmox_password:
             credentials = urlencode({"username": self.proxmox_user, "password": self.proxmox_password})
             a = self._get_session()
-            ret = a.post(f"{self.proxmox_url}/api2/json/access/ticket", data=credentials)
+            ret = a.post(
+                f"{self.proxmox_url}/api2/json/access/ticket",
+                data=credentials,
+                timeout=self.request_timeout,
+            )
             json = ret.json()
             self.headers = {
                 # only required for POST/PUT/DELETE methods, which we are not using currently
@@ -323,7 +334,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not has_data:
             s = self._get_session()
             while True:
-                ret = s.get(url, headers=self.headers)
+                ret = s.get(url, headers=self.headers, timeout=self.request_timeout)
                 if ignore_errors and ret.status_code in ignore_errors:
                     break
                 ret.raise_for_status()
@@ -351,14 +362,23 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         return make_unsafe(data)
 
     def _get_nodes(self):
+        display.vvv("Fetching Proxmox cluster status")
         cluster_status = self._get_json(f"{self.proxmox_url}/api2/json/cluster/status")
-        return [item for item in cluster_status if item["type"] == "node"]
+        nodes = [item for item in cluster_status if item["type"] == "node"]
+        display.vvv(f"Fetched {len(nodes)} Proxmox nodes")
+        return nodes
 
     def _get_pools(self):
-        return self._get_json(f"{self.proxmox_url}/api2/json/pools")
+        display.vvv("Fetching Proxmox pools")
+        pools = self._get_json(f"{self.proxmox_url}/api2/json/pools")
+        display.vvv(f"Fetched {len(pools)} Proxmox pools")
+        return pools
 
     def _get_vms(self):
-        return self._get_json(f"{self.proxmox_url}/api2/json/cluster/resources?type=vm")
+        display.vvv("Fetching Proxmox VM resources")
+        vms = self._get_json(f"{self.proxmox_url}/api2/json/cluster/resources?type=vm")
+        display.vvv(f"Fetched {len(vms)} Proxmox VM resources")
+        return vms
 
     def _get_vms_by_node(self):
         vms_by_node = {"qemu": {}, "lxc": {}}
@@ -374,11 +394,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             node_items = vms_by_node[ittype].setdefault(item["node"], [])
             node_items.append(item)
 
+        display.vvv(
+            "Grouped Proxmox VM resources into "
+            f"{sum(len(items) for items in vms_by_node['qemu'].values())} QEMU guests and "
+            f"{sum(len(items) for items in vms_by_node['lxc'].values())} LXC guests"
+        )
         return vms_by_node
 
     def _get_members_per_pool(self, pool):
+        display.vvv(f"Fetching Proxmox pool members for {pool}")
         ret = self._get_json(f"{self.proxmox_url}/api2/json/pools/{pool}")
-        return ret["members"]
+        members = ret["members"]
+        display.vvv(f"Fetched {len(members)} Proxmox pool members for {pool}")
+        return members
 
     def _get_lxc_interfaces(self, properties, node, vmid):
         status_key = self._fact("status")
@@ -521,10 +549,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if ittype == "lxc":
             self._get_lxc_interfaces(properties, node, vmid)
 
+    def _safe_get_guest_facts(self, properties, node, vmid, ittype, name):
+        try:
+            self._get_guest_facts(properties, node, vmid, ittype, name)
+        except Exception as e:  # pylint: disable=broad-except
+            properties[self._fact("fact_gathering_failed")] = True
+            properties[self._fact("fact_gathering_error")] = str(e)
+            display.warning(f"Could not gather Proxmox guest facts for {node}/{ittype}/{vmid} ({name}) - {e}")
+
     def _get_guest_facts_for_item(self, node, ittype, item):
-        display.vvvv(f"Gathering Proxmox guest facts for {node}/{ittype}/{item['vmid']} ({item['name']})")
         properties = {}
-        self._get_guest_facts(properties, node, item["vmid"], ittype, item["name"])
+        self._safe_get_guest_facts(properties, node, item["vmid"], ittype, item["name"])
+        display.vvvv(f"Gathered Proxmox guest facts for {node}/{ittype}/{item['vmid']} ({item['name']})")
         return node, ittype, item["vmid"], properties
 
     def _get_guest_facts_by_item(self, items):
@@ -543,7 +579,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 guest_facts_by_item[(result_node, result_ittype, vmid)] = properties
             return guest_facts_by_item
 
-        with ThreadPoolExecutor(max_workers=self.facts_concurrency) as executor:
+        executor = ThreadPoolExecutor(max_workers=self.facts_concurrency)
+        try:
             futures = [
                 executor.submit(self._get_guest_facts_for_item, node, ittype, item)
                 for node, ittype, item in items
@@ -551,6 +588,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for future in as_completed(futures):
                 node, ittype, vmid, properties = future.result()
                 guest_facts_by_item[(node, ittype, vmid)] = properties
+        except KeyboardInterrupt:
+            pending_futures = sum(1 for future in futures if not future.done())
+            running_futures = sum(1 for future in futures if future.running())
+            display.warning(
+                "Interrupted Proxmox guest fact gathering with "
+                f"{pending_futures} pending tasks, {running_futures} running"
+            )
+            executor.shutdown(wait=False, cancel_futures=True)
+            raise
+        else:
+            executor.shutdown(wait=True)
 
         return guest_facts_by_item
 
@@ -620,7 +668,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if guest_facts is not None:
                 properties.update(guest_facts)
             else:
-                self._get_guest_facts(properties, node, vmid, ittype, name)
+                self._safe_get_guest_facts(properties, node, vmid, ittype, name)
 
         # ensure the host satisfies filters
         if not self._can_add_host(name, properties):
@@ -629,7 +677,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # get status, config and snapshots if we want_post_filter_facts only
         want_post_filter_facts = self.get_option("want_post_filter_facts")
         if not want_facts and want_post_filter_facts:
-            self._get_guest_facts(properties, node, vmid, ittype, name)
+            self._safe_get_guest_facts(properties, node, vmid, ittype, name)
 
         # add the host to the inventory
         self._add_host(name, properties)
@@ -745,10 +793,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise AnsibleError("You must set want_facts to True if you want to use qemu_extended_statuses.")
         if self.get_option("facts_concurrency") < 1:
             raise AnsibleError("You must set facts_concurrency to 1 or greater.")
+        if self.get_option("request_timeout") < 1:
+            raise AnsibleError("You must set request_timeout to 1 or greater.")
         # read rest of options
         self.exclude_nodes = self.get_option("exclude_nodes")
         self.exclude_vms = self.get_option("exclude_vms")
         self.facts_concurrency = self.get_option("facts_concurrency")
+        self.request_timeout = self.get_option("request_timeout")
         self.cache_key = self.get_cache_key(path)
         self.use_cache = cache and self.get_option("cache")
         self.update_cache = not cache and self.get_option("cache")

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -865,9 +865,7 @@ def test_get_guest_facts_by_item_serial(inventory, mocker):
     }
 
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
-    thread_pool = mocker.patch(
-        "ansible_collections.community.proxmox.plugins.inventory.proxmox.ThreadPoolExecutor"
-    )
+    thread_pool = mocker.patch("ansible_collections.community.proxmox.plugins.inventory.proxmox.ThreadPoolExecutor")
 
     def get_guest_facts_for_item(node, ittype, item):
         return node, ittype, item["vmid"], {"fact": ittype}
@@ -905,9 +903,7 @@ def test_get_guest_facts_by_item_cancels_pending_futures_on_interrupt(inventory,
         "ansible_collections.community.proxmox.plugins.inventory.proxmox.ThreadPoolExecutor",
         return_value=executor,
     )
-    display_warning = mocker.patch(
-        "ansible_collections.community.proxmox.plugins.inventory.proxmox.display.warning"
-    )
+    display_warning = mocker.patch("ansible_collections.community.proxmox.plugins.inventory.proxmox.display.warning")
     mocker.patch(
         "ansible_collections.community.proxmox.plugins.inventory.proxmox.as_completed",
         side_effect=KeyboardInterrupt,
@@ -921,9 +917,7 @@ def test_get_guest_facts_by_item_cancels_pending_futures_on_interrupt(inventory,
         )
 
     thread_pool.assert_called_once_with(max_workers=8)
-    display_warning.assert_called_once_with(
-        "Interrupted Proxmox guest fact gathering with 1 pending tasks, 1 running"
-    )
+    display_warning.assert_called_once_with("Interrupted Proxmox guest fact gathering with 1 pending tasks, 1 running")
     executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
 
 
@@ -992,4 +986,6 @@ def test_handle_item_adds_dynamic_status_group(inventory, mocker):
     name = inventory._handle_item("testnode", "qemu", item, guest_facts={"proxmox_qmpstatus": "prelaunch"})
 
     assert name == "test-qemu-prelaunch"
-    assert inventory.inventory.get_host("test-qemu-prelaunch") in inventory.inventory.groups["proxmox_all_prelaunch"].hosts
+    assert (
+        inventory.inventory.get_host("test-qemu-prelaunch") in inventory.inventory.groups["proxmox_all_prelaunch"].hosts
+    )

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -934,12 +934,12 @@ def test_get_guest_facts_for_item_marks_failed_fact_gathering(inventory, mocker)
     assert properties["proxmox_fact_gathering_error"] == "timed out"
 
 
-def test_get_json_uses_request_timeout(inventory, mocker):
+def test_get_json_uses_api_timeout(inventory, mocker):
     inventory.use_cache = False
     inventory._results = {}
     inventory._results_lock = mocker.MagicMock()
     inventory.headers = {}
-    inventory.request_timeout = 12
+    inventory.api_timeout = 12
 
     response = mocker.MagicMock()
     response.status_code = 200

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -888,6 +888,80 @@ def test_get_guest_facts_by_item_serial(inventory, mocker):
     thread_pool.assert_not_called()
 
 
+def test_get_guest_facts_by_item_cancels_pending_futures_on_interrupt(inventory, mocker):
+    inventory.facts_concurrency = 8
+
+    opts = {
+        "want_facts": True,
+    }
+
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    executor = mocker.MagicMock()
+    future = mocker.MagicMock()
+    future.done.return_value = False
+    future.running.return_value = True
+    executor.submit.return_value = future
+    thread_pool = mocker.patch(
+        "ansible_collections.community.proxmox.plugins.inventory.proxmox.ThreadPoolExecutor",
+        return_value=executor,
+    )
+    display_warning = mocker.patch(
+        "ansible_collections.community.proxmox.plugins.inventory.proxmox.display.warning"
+    )
+    mocker.patch(
+        "ansible_collections.community.proxmox.plugins.inventory.proxmox.as_completed",
+        side_effect=KeyboardInterrupt,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        inventory._get_guest_facts_by_item(
+            [
+                ("testnode", "qemu", {"name": "test-qemu", "vmid": "101"}),
+            ]
+        )
+
+    thread_pool.assert_called_once_with(max_workers=8)
+    display_warning.assert_called_once_with(
+        "Interrupted Proxmox guest fact gathering with 1 pending tasks, 1 running"
+    )
+    executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+
+
+def test_get_guest_facts_for_item_marks_failed_fact_gathering(inventory, mocker):
+    inventory.facts_prefix = "proxmox_"
+    inventory._get_guest_facts = mocker.MagicMock(side_effect=TimeoutError("timed out"))
+
+    node, ittype, vmid, properties = inventory._get_guest_facts_for_item(
+        "testnode", "qemu", {"name": "test-qemu", "vmid": "101"}
+    )
+
+    assert (node, ittype, vmid) == ("testnode", "qemu", "101")
+    assert properties["proxmox_fact_gathering_failed"] is True
+    assert properties["proxmox_fact_gathering_error"] == "timed out"
+
+
+def test_get_json_uses_request_timeout(inventory, mocker):
+    inventory.use_cache = False
+    inventory._results = {}
+    inventory._results_lock = mocker.MagicMock()
+    inventory.headers = {}
+    inventory.request_timeout = 12
+
+    response = mocker.MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"data": [{"name": "test"}]}
+    session = mocker.MagicMock()
+    session.get.return_value = response
+    inventory._get_session = mocker.MagicMock(return_value=session)
+
+    assert inventory._get_json("https://localhost:8006/api2/json/test") == [{"name": "test"}]
+    session.get.assert_called_once_with(
+        "https://localhost:8006/api2/json/test",
+        headers={},
+        timeout=12,
+    )
+
+
 def test_handle_item_adds_dynamic_status_group(inventory, mocker):
     inventory.proxmox_url = "https://localhost:8006"
     inventory.group_prefix = "proxmox_"

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -11,7 +11,7 @@ from ansible.inventory.data import InventoryData
 from ansible_collections.community.proxmox.plugins.inventory.proxmox import InventoryModule
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def inventory():
     r = InventoryModule()
     r.inventory = InventoryData()
@@ -33,23 +33,77 @@ def get_auth():
 
 
 API_RESPONSES = {
-    "https://localhost:8006/api2/json/nodes": [
+    "https://localhost:8006/api2/json/cluster/status": [
         {
             "type": "node",
-            "cpu": 0.01,
-            "maxdisk": 500,
-            "mem": 500,
-            "node": "testnode",
+            "name": "testnode",
             "id": "node/testnode",
-            "maxcpu": 1,
-            "status": "online",
-            "ssl_fingerprint": "xx",
-            "disk": 1000,
-            "maxmem": 1000,
-            "uptime": 10000,
+            "online": 1,
+            "local": 1,
+            "nodeid": 1,
+            "ip": "10.0.10.1",
             "level": "",
         },
-        {"type": "node", "node": "testnode2", "id": "node/testnode2", "status": "offline", "ssl_fingerprint": "yy"},
+        {
+            "type": "node",
+            "name": "testnode2",
+            "id": "node/testnode2",
+            "online": 0,
+            "local": 0,
+            "nodeid": 2,
+            "ip": "10.0.10.2",
+            "level": "",
+        },
+        {
+            "type": "cluster",
+            "quorate": 1,
+            "name": "testcluster",
+            "version": 24,
+            "id": "cluster",
+            "nodes": 2,
+        },
+    ],
+    "https://localhost:8006/api2/json/cluster/resources?type=vm": [
+        {
+            "name": "test-lxc",
+            "node": "testnode",
+            "template": "",
+            "type": "lxc",
+            "status": "running",
+            "vmid": "100",
+        },
+        {
+            "name": "test-qemu",
+            "node": "testnode",
+            "template": "",
+            "type": "qemu",
+            "status": "running",
+            "vmid": "101",
+        },
+        {
+            "name": "test-qemu-windows",
+            "node": "testnode",
+            "template": "",
+            "type": "qemu",
+            "status": "running",
+            "vmid": "102",
+        },
+        {
+            "name": "test-qemu-multi-nic",
+            "node": "testnode",
+            "template": "",
+            "type": "qemu",
+            "status": "running",
+            "vmid": "103",
+        },
+        {
+            "name": "test-qemu-template",
+            "node": "testnode",
+            "template": 1,
+            "type": "qemu",
+            "status": "stopped",
+            "vmid": "9001",
+        },
     ],
     "https://localhost:8006/api2/json/pools": [{"poolid": "test"}],
     "https://localhost:8006/api2/json/nodes/testnode/lxc": [
@@ -570,14 +624,17 @@ def test_populate(inventory, mocker):
     inventory.facts_prefix = "proxmox_"
     inventory.strict = False
     inventory.exclude_nodes = False
+    inventory.exclude_vms = False
 
     opts = {
         "group_prefix": "proxmox_",
         "facts_prefix": "proxmox_",
         "want_facts": True,
+        "facts_concurrency": 1,
         "want_proxmox_nodes_ansible_host": True,
         "qemu_extended_statuses": True,
         "exclude_nodes": False,
+        "exclude_vms": False,
     }
 
     # bypass authentication and API fetch calls
@@ -587,6 +644,7 @@ def test_populate(inventory, mocker):
     inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
     inventory._can_add_host = mocker.MagicMock(return_value=True)
     inventory._populate()
+    called_urls = [call.args[0] for call in inventory._get_json.call_args_list]
 
     # get different hosts
     host_qemu = inventory.inventory.get_host("test-qemu")
@@ -642,6 +700,10 @@ def test_populate(inventory, mocker):
     group_paused = inventory.inventory.groups["proxmox_all_paused"]
     assert group_paused.hosts == [host_qemu_multi_nic]
 
+    assert "https://localhost:8006/api2/json/cluster/resources?type=vm" in called_urls
+    assert "https://localhost:8006/api2/json/nodes/testnode/qemu" not in called_urls
+    assert "https://localhost:8006/api2/json/nodes/testnode/lxc" not in called_urls
+
 
 def test_populate_missing_qemu_extended_groups(inventory, mocker):
     # module settings
@@ -652,14 +714,17 @@ def test_populate_missing_qemu_extended_groups(inventory, mocker):
     inventory.facts_prefix = "proxmox_"
     inventory.strict = False
     inventory.exclude_nodes = False
+    inventory.exclude_vms = False
 
     opts = {
         "group_prefix": "proxmox_",
         "facts_prefix": "proxmox_",
         "want_facts": True,
+        "facts_concurrency": 1,
         "want_proxmox_nodes_ansible_host": True,
         "qemu_extended_statuses": False,
         "exclude_nodes": False,
+        "exclude_vms": False,
     }
 
     # bypass authentication and API fetch calls
@@ -684,14 +749,17 @@ def test_populate_exclude_nodes(inventory, mocker):
     inventory.facts_prefix = "proxmox_"
     inventory.strict = False
     inventory.exclude_nodes = True
+    inventory.exclude_vms = False
 
     opts = {
         "group_prefix": "proxmox_",
         "facts_prefix": "proxmox_",
         "want_facts": True,
+        "facts_concurrency": 1,
         "want_proxmox_nodes_ansible_host": True,
         "qemu_extended_statuses": False,
         "exclude_nodes": True,
+        "exclude_vms": False,
     }
 
     # bypass authentication and API fetch calls
@@ -710,3 +778,144 @@ def test_populate_exclude_nodes(inventory, mocker):
     # make sure that nodes are not in the "ungrouped" group
     for node in ["testnode", "testnode2"]:
         assert node not in inventory.inventory.get_groups_dict()["ungrouped"]
+
+
+def test_populate_exclude_vms(inventory, mocker):
+    # module settings
+    inventory.proxmox_user = "root@pam"
+    inventory.proxmox_password = "password"
+    inventory.proxmox_url = "https://localhost:8006"
+    inventory.group_prefix = "proxmox_"
+    inventory.facts_prefix = "proxmox_"
+    inventory.strict = False
+    inventory.exclude_nodes = False
+    inventory.exclude_vms = True
+
+    opts = {
+        "group_prefix": "proxmox_",
+        "facts_prefix": "proxmox_",
+        "want_facts": False,
+        "facts_concurrency": 1,
+        "want_proxmox_nodes_ansible_host": True,
+        "qemu_extended_statuses": False,
+        "exclude_nodes": False,
+        "exclude_vms": True,
+    }
+
+    # bypass authentication and API fetch calls
+    inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
+    inventory._get_json = mocker.MagicMock(side_effect=get_json)
+    inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    inventory._can_add_host = mocker.MagicMock(return_value=True)
+    inventory._populate()
+
+    assert inventory.inventory.get_host("testnode")
+    assert inventory.inventory.get_host("testnode2")
+    assert inventory.inventory.get_host("test-lxc") is None
+    assert inventory.inventory.get_host("test-qemu") is None
+    assert inventory.inventory.get_host("test-qemu-windows") is None
+    assert inventory.inventory.get_host("test-qemu-multi-nic") is None
+    assert inventory.inventory.get_host("test-qemu-template") is None
+    assert inventory.inventory.groups["proxmox_all_lxc"].hosts == []
+    assert inventory.inventory.groups["proxmox_all_qemu"].hosts == []
+    assert "proxmox_testnode_lxc" not in inventory.inventory.groups
+    assert "proxmox_testnode_qemu" not in inventory.inventory.groups
+
+    called_urls = [call.args[0] for call in inventory._get_json.call_args_list]
+    assert "https://localhost:8006/api2/json/cluster/resources?type=vm" not in called_urls
+    assert "https://localhost:8006/api2/json/nodes/testnode/qemu" not in called_urls
+    assert "https://localhost:8006/api2/json/nodes/testnode/lxc" not in called_urls
+    assert "https://localhost:8006/api2/json/pools" not in called_urls
+    assert "https://localhost:8006/api2/json/pools/test" not in called_urls
+
+
+def test_get_guest_facts_by_item_concurrent(inventory, mocker):
+    inventory.facts_concurrency = 8
+
+    opts = {
+        "want_facts": True,
+    }
+
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+
+    def get_guest_facts_for_item(node, ittype, item):
+        return node, ittype, item["vmid"], {"fact": ittype}
+
+    inventory._get_guest_facts_for_item = mocker.MagicMock(side_effect=get_guest_facts_for_item)
+
+    guest_facts_by_item = inventory._get_guest_facts_by_item(
+        [
+            ("testnode", "qemu", {"name": "test-qemu", "vmid": "101"}),
+            ("testnode", "lxc", {"name": "test-lxc", "vmid": "100"}),
+        ]
+    )
+
+    assert guest_facts_by_item == {
+        ("testnode", "qemu", "101"): {"fact": "qemu"},
+        ("testnode", "lxc", "100"): {"fact": "lxc"},
+    }
+
+
+def test_get_guest_facts_by_item_serial(inventory, mocker):
+    inventory.facts_concurrency = 1
+
+    opts = {
+        "want_facts": True,
+    }
+
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    thread_pool = mocker.patch(
+        "ansible_collections.community.proxmox.plugins.inventory.proxmox.ThreadPoolExecutor"
+    )
+
+    def get_guest_facts_for_item(node, ittype, item):
+        return node, ittype, item["vmid"], {"fact": ittype}
+
+    inventory._get_guest_facts_for_item = mocker.MagicMock(side_effect=get_guest_facts_for_item)
+
+    guest_facts_by_item = inventory._get_guest_facts_by_item(
+        [
+            ("testnode", "qemu", {"name": "test-qemu", "vmid": "101"}),
+            ("testnode", "lxc", {"name": "test-lxc", "vmid": "100"}),
+        ]
+    )
+
+    assert guest_facts_by_item == {
+        ("testnode", "qemu", "101"): {"fact": "qemu"},
+        ("testnode", "lxc", "100"): {"fact": "lxc"},
+    }
+    thread_pool.assert_not_called()
+
+
+def test_handle_item_adds_dynamic_status_group(inventory, mocker):
+    inventory.proxmox_url = "https://localhost:8006"
+    inventory.group_prefix = "proxmox_"
+    inventory.facts_prefix = "proxmox_"
+    inventory.strict = False
+
+    opts = {
+        "compose": {},
+        "groups": {},
+        "keyed_groups": [],
+        "want_facts": True,
+        "want_post_filter_facts": False,
+        "qemu_extended_statuses": True,
+    }
+
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    inventory._can_add_host = mocker.MagicMock(return_value=True)
+    inventory.inventory.add_group("proxmox_all_qemu")
+    inventory.inventory.add_group("proxmox_testnode_qemu")
+
+    item = {
+        "name": "test-qemu-prelaunch",
+        "vmid": "104",
+        "status": "running",
+        "template": "",
+    }
+
+    name = inventory._handle_item("testnode", "qemu", item, guest_facts={"proxmox_qmpstatus": "prelaunch"})
+
+    assert name == "test-qemu-prelaunch"
+    assert inventory.inventory.get_host("test-qemu-prelaunch") in inventory.inventory.groups["proxmox_all_prelaunch"].hosts


### PR DESCRIPTION
##### SUMMARY
Using the inventory plugin is very slow due to multiple looping API calls, especially over WAN links. This PR addresses this in four ways:

1. Change the node list API call from `/api2/json/nodes` to `/api2/json/cluster/status`, since the latter already includes the management IP in the payload.
2. Fetch QEMU and LXC inventory records from `/api2/json/cluster/resources?type=vm` instead of querying every online node's QEMU and LXC endpoints.
3. Add `exclude_vms` so users can skip QEMU/LXC discovery entirely when they only need Proxmox nodes.
4. Add `facts_concurrency` so users can opt into bounded concurrent guest fact collection when `want_facts: true`.

Fetching the inventory for nodes and VMs is now done in one or two single requests, which cuts the wait dramatically. When you need VM facts, it fans out and fetches them in parallel if you want, which also add large time savings. These fixes make it possible to use the inventory plugin against some of my big remote clusters, whereas before it could take 10-20+ minutes or simple never complete.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
Inventory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Sample response from `/api2/json/cluster/status`
```json
{
    "data": [
        {
            "type": "cluster",
            "quorate": 1,
            "name": "svg001pve",
            "version": 24,
            "id": "cluster",
            "nodes": 3
        },
        {
            "level": "",
            "id": "node/svg025pve",
            "online": 1,
            "type": "node",
            "local": 1,
            "nodeid": 3,
            "ip": "192.168.7.75",
            "name": "svg025pve"
        },
        {
            "id": "node/svg013pve",
            "online": 1,
            "level": "",
            "name": "svg013pve",
            "ip": "192.168.7.63",
            "nodeid": 2,
            "type": "node",
            "local": 0
        },
        {
            "level": "",
            "online": 1,
            "id": "node/svg011pve",
            "local": 0,
            "type": "node",
            "nodeid": 1,
            "ip": "192.168.7.61",
            "name": "svg011pve"
        }
    ]
}
```

The inventory plugin now uses `/api2/json/cluster/resources?type=vm` for the initial QEMU/LXC records. This keeps the existing host variables and groups, while avoiding separate `/nodes/{node}/qemu` and `/nodes/{node}/lxc` list calls for each online node. Full guest facts are still fetched separately when `want_facts` or `want_post_filter_facts` requires them.

Sample response from `/api2/json/cluster/resources?type=vm`
```json
{
    "data": [
        {
            "id": "qemu/101",
            "name": "app01",
            "node": "pve01",
            "pool": "production",
            "status": "running",
            "template": 0,
            "type": "qemu",
            "vmid": 101
        },
        {
            "id": "lxc/201",
            "name": "web01",
            "node": "pve02",
            "pool": "production",
            "status": "running",
            "tags": "linux;web",
            "template": 0,
            "type": "lxc",
            "vmid": 201
        }
    ]
}
```

New option to exclude VM discovery:
```yaml
plugin: community.proxmox.proxmox
url: https://pvehost:8006
want_proxmox_nodes_ansible_host: true
exclude_nodes: false
exclude_vms: true
```

New option to gather guest facts concurrently:
```yaml
plugin: community.proxmox.proxmox
url: https://pvehost:8006
want_facts: true
facts_concurrency: 8
```

`facts_concurrency` defaults to `1`, which preserves the previous serial behavior. Higher values can reduce runtime over slow links, but increase load on the Proxmox API.

Performance highlights from live inventory runs against remote cluster (~100ms ping) with 24 Nodes, ~450 VMs (qemu/lxc/templates):

| Configuration | Before | After |
| --- | ---: | ---: |
| `want_facts: false` | `1m:46s` | `3.4s` |
| `want_facts: false`, `exclude_vms: true` | `1m:44s` | `0.9s` |
| `want_facts: true`, `facts_concurrency: 8` | `13m15s` | `1m52s` |

##### TODO
Consider migrating to `proxmoxer`.