### PR TITLE
docs: use correct starting number of interface

### DIFF
--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -28,7 +28,7 @@ options:
     default: false
   interface:
     description:
-      - Name of the interface, should be V(net[n]) where C(1 ≤ n ≤ 31).
+      - Name of the interface, should be V(net[n]) where C(0 ≤ n ≤ 31).
     type: str
     required: true
   link_down:


### PR DESCRIPTION
##### SUMMARY

Fixes #79

Upper limit confirmed here: [QemuServer/PCI.pm](https://git.proxmox.com/?p=qemu-server.git;a=blob;f=src/PVE/QemuServer/PCI.pm;h=c9cf8de0b33cbd8108f119aa6ff470f83cc3f290;hb=HEAD#l178)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_nic`

##### ADDITIONAL INFORMATION

Idk if a doc update requires an entry on changelog, let me know.
