### PR TITLE
docs: clarify kvm disk cdrom interfaces config

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -219,8 +219,7 @@ options:
       - Keys must be C(ide[n]) where 0 ≤ n ≤ 3.
       - Values are strings containing comma-separated options in the format V(<storage>:<size>[,option=value]...)
       - 'Examples: V("<storage>:10,format=qcow2") for a disk, or V("<storage>:iso/debian.iso,media=cdrom") for a CD-ROM.'
-      - |
-        For a complete list of all available options, please refer to the Proxmox VE documentation
+      - For a complete list of all available options, please refer to the Proxmox VE documentation
         (look for "ide[n]:") at U(https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_options).
     type: dict
   ipconfig:


### PR DESCRIPTION
##### SUMMARY

(try to) Clarify the documentation about the configuration of sata, ide, scsi, and virtio interfaces of the `proxmox_kvm` module.

Also, fixes the scsi limit which is ≤ 30.

Fixes #27 #93

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_kvm`

##### ADDITIONAL INFORMATION

Let me know what you think


