### PR TITLE
docs: enhance net option params description

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -295,15 +295,12 @@ options:
       - A hash/dictionary of network interfaces for the VM.
       - Keys must be C(net[n]) where 0 ≤ n ≤ N.
       - Values are strings containing comma-separated options in the format V([model=]<enum>[,option=value]...)
-      - |
-        Examples: V("virtio,bridge=vmbr0") for a basic interface, or V("virtio,bridge=vmbr0,firewall=1,rate=200,tag=10")
-        for a rate-limited VLAN interface with firewall enabled.
-      - |
-        V(macaddr=XX:XX:XX:XX:XX:XX) must be a unique MAC address.
+      - 'Examples: V("virtio,bridge=vmbr0") for a basic interface, or V("virtio,bridge=vmbr0,firewall=1,rate=200,tag=10")
+        for a rate-limited VLAN interface with firewall enabled.'
+      - V(macaddr=XX:XX:XX:XX:XX:XX) must be a unique MAC address.
         If not specified, a unique MAC address is automatically generated.
-      - |
-        For a complete list of all available options, please refer to the Proxmox VE documentation (look for "net[n]:") at
-        U(https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_options).
+      - For a complete list of all available options, please refer to the Proxmox VE documentation (look for "net[n]:") at
+        U(https://pve.proxmox.com/pve-docs/chapter-qm.html\#qm_options).
     type: dict
   newid:
     description:


### PR DESCRIPTION
##### SUMMARY

(try to) enhance the usage of `net` on `proxmox_kvm` in the module doc.

Fixes #78

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_kvm`
