### PR TITLE
docs: clarify usage of options stopped/force/timeout on kvm module

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -165,9 +165,6 @@ options:
       - When used with O(state=stopped), attempts a graceful shutdown
         and if the VM is still running after O(timeout), it will be forcefully powered off.
       - When used with O(state=restarted), performs reset (power off and on) and not a graceful reboot.
-      - When used with O(state=stopped), attempts a graceful shutdown
-        and if the VM is still running after O(timeout), it will be forcefully powered off.
-        And finally perfoms the delete.
     type: bool
   format:
     description:
@@ -493,8 +490,8 @@ options:
   timeout:
     description:
       - Timeout in seconds for operations.
-      - If the timeout is reach with O(state=stopped) and O(force=True), the VM will be forcefully powered off.
-      - If the timeout is reach with O(state=stopped) and O(force=False), the task will fail.
+      - If the timeout is reached with O(state=stopped) and O(force=True), the VM will be forcefully powered off.
+      - If the timeout is reached with O(state=stopped) and O(force=False), the task will fail.
     type: int
     default: 30
   tpmstate0:


### PR DESCRIPTION
##### SUMMARY

(try to) clarify the `force`, `timeout`, and `state: stopped` parameters on `proxmox_kvm`.

Not easy, because as you already know, this module is a real mess and should needs a complete rewrite, but I'm just trying to improve the module doc, without really intending to tackle it for now.

Related to: #22

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_kvm`
