### PR TITLE
Add stricter linting rules

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-src_paths=plugins

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -11,12 +11,11 @@
 [sessions]
 
 [sessions.lint]
-run_isort = true
 run_ruff_check = true
 ruff_check_config = "ruff.toml"
 run_ruff_format = true
 ruff_format_config = "ruff.toml"
-isort_config = ".isort.cfg"
+run_isort = false
 run_black = false
 run_flake8 = false
 run_pylint = false


### PR DESCRIPTION
##### SUMMARY
This PR changes the antsibull settings, to enable linting and code quality assessments within the ci pipeline. There were several PRs in the past, which had python errors, which would have been caught automatically.

This way  we can improve the code quality over time and save time checking newly submitted code, because: it passes basic logic tests and coding conventions, it is using docstrings for public functions and our code gets a uniform writing style.

The configuration is copied mostly from community.general - a project be can use as a guideline in most regards i suppose. Additionally, isort support was added and ruffs pylint ruleset was activated as well.


##### Impact on other users
The current CI configuration does check the whole code in this repo as one (I think?). Therefore, contributors submitting bugfixes will encounter failing ci tasks for files they are not responsible for. But nevertheless, even if they change a line in an existing module, they might get CI errors of code they did not handle.

I don't have a solution at hand how to resolve this matter. Overall it is benificial to the code quality of this project to use the features antsibull-nox provides, but I don't want to keep new contributors from providing bugfixes, because they  don't want to fix the code as well.

##### ISSUE TYPE

- Code quality PR