### PR TITLE
Remove experimental ruff features from ruff.toml and disable docstrings for doc_fragments

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,7 +8,7 @@ include = ["tests/**/*.py", "plugins/**/*.py"]
 [lint]
 # https://docs.astral.sh/ruff/rules/
 
-select = ["A", "B", "D", "DOC", "E", "F", "FA", "FLY", "UP", "SIM", "I", "RUF022", "PL"]
+select = ["A", "B", "D", "E", "F", "FA", "FLY", "UP", "SIM", "I", "RUF022", "PL"]
 ignore = [
     # Better keep ignored (for now)
     "F811",  # Redefinition of unused `xxx` (happens a lot for fixtures in unit tests)
@@ -34,11 +34,12 @@ dummy-variable-rgx = "^(_|dummy).*$"
 
 [lint.per-file-ignores]
 # Don't require docstrings
-"tests/*" = ["D","DOC"]
-"plugins/connection/*" = ["D","DOC"]
-"plugins/modules/*" = ["D","DOC"]
-"plugins/inventory/*" = ["D","DOC"]
-"plugins/plugin/*" = ["D","DOC"]
+"tests/*" = ["D"]
+"plugins/connection/*" = ["D"]
+"plugins/modules/*" = ["D"]
+"plugins/inventory/*" = ["D"]
+"plugins/plugin/*" = ["D"]
+"plugins/doc_fragments/*" = ["D"]
 
 [lint.pydocstyle]
 # force users to include their variables in docstrings to improve editor support


### PR DESCRIPTION
This PR  removes pydoclint settings from ruff, since it is still an experimental feature. Furthermore the docstring requirement gets removed for doc_fragments.