### PR TITLE
Modify docstring requirements in ruff.toml

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: 2025 Felix Fontein <felix@fontein.de>
 
 line-length = 120
-include = ["tests/**/*.py", "plugins/**/*.py"]
 
 [lint]
 # https://docs.astral.sh/ruff/rules/
@@ -34,7 +33,7 @@ dummy-variable-rgx = "^(_|dummy).*$"
 
 [lint.per-file-ignores]
 # Only require docstrings for shared utils
-"!plugins/*_utils/*.py" = ["D"]
+"!**/*_utils/*.py" = ["D"]
 
 [lint.pydocstyle]
 # force users to include their variables in docstrings to improve editor support


### PR DESCRIPTION
Updated per-file ignores to only require docstrings for shared utils. The pattern matching beforehand was incorrect and inefficient, a negated setting should do the trick, see https://docs.astral.sh/ruff/settings#lint_per-file-ignores