### PR TITLE
style(test_proxmox_vm_info): fix ruff rule PLR2004 (duplicate assert)

### DIFF
--- a/tests/unit/plugins/modules/test_proxmox_vm_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_vm_info.py
@@ -483,7 +483,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_specific_qemu_vm_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -494,7 +493,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_specific_vm_information(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -505,7 +503,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_specific_vm_information_by_using_name(self):
         name = "test1-lxc.home.arpa"
@@ -518,7 +515,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_multiple_vms_with_the_same_name(self):
         name = "test-lxc.home.arpa"
@@ -548,7 +544,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_all_lxc_vms_from_specific_node(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -558,7 +553,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_all_qemu_vms_from_specific_node(self):
         with pytest.raises(AnsibleExitJson) as exc_info:
@@ -568,7 +562,6 @@ class TestProxmoxVmInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["proxmox_vms"] == expected_output
-        assert len(result["proxmox_vms"]) == 1
 
     def test_get_all_vms_from_specific_node(self):
         with pytest.raises(AnsibleExitJson) as exc_info:


### PR DESCRIPTION
##### SUMMARY

Remove these assertions since it's redondant with `assert result["proxmox_vms"] == expected_output`

Another step toward fixing the remaining Ruff lint errors.

This one addresses the Ruff rule [PLR2004](https://docs.astral.sh/ruff/rules/magic-value-comparison/) (which fixes 2 lint issues) on file `test_proxmox_vm_info.py`.

First commit remove redondant assertions that cause lint issues. The second one remove remaining redondant assertions (not triggered by lint rule).


