### PR TITLE
style: remove trailing whitespace (extra-checks)

### DIFF
--- a/changelogs/fragments/pr270.yml
+++ b/changelogs/fragments/pr270.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
   - proxmox_storage_contents_info - Add support for content type ``import`` (https://github.com/ansible-collections/community.proxmox/pull/260).
-  


### PR DESCRIPTION
##### SUMMARY

Running locally `nox -e extra-checks` raise one issue:

```log
changelogs/fragments/pr270.yml:4:
  found trailing whitespace
⋮ │   
3 │     - proxmox_storage_contents_info - Add support for content type ``import`` (https://github.com/ansible-collections/community.proxmox/pull/260).
4 │ →   
nox > Session extra-checks aborted: no-trailing-whitespace failed (took a second).
```

This PR fixes it.

