### PR TITLE
style(storage_contents_info): format

### DIFF
--- a/plugins/modules/proxmox_storage_contents_info.py
+++ b/plugins/modules/proxmox_storage_contents_info.py
@@ -108,7 +108,9 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
 def proxmox_storage_info_argument_spec():
     return dict(
         storage=dict(type="str", required=True, aliases=["name"]),
-        content=dict(type="str", required=False, default="all", choices=["all", "backup", "rootdir", "images", "iso", "import"]),
+        content=dict(
+            type="str", required=False, default="all", choices=["all", "backup", "rootdir", "images", "iso", "import"]
+        ),
         vmid=dict(type="int"),
         node=dict(required=True, type="str"),
     )


### PR DESCRIPTION
##### SUMMARY

Running locally, `nox -e formatters` format one remaining file, this PR fixes it.

Format `proxmox_storage_contents_info.py`.

##### COMPONENT NAME

`proxmox_storage_contents_info`