### PR TITLE
feat: add support for nested pools

### DIFF
--- a/changelogs/fragments/299-nested-pools.yml
+++ b/changelogs/fragments/299-nested-pools.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - proxmox - add support for retrieving nested pools (https://github.com/ansible-collections/community.proxmox/pull/306).
+  - proxmox_pool - add support for removing nested pools (https://github.com/ansible-collections/community.proxmox/pull/306).
+  - proxmox_pool_member - add support for adding and removing nested pool members (https://github.com/ansible-collections/community.proxmox/pull/306).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -365,7 +365,10 @@ class ProxmoxAnsible:
             dict: Pool information.
         """
         try:
-            return self.proxmox_api.pools(poolid).get()
+            if self.version() >= LooseVersion("8.1"):
+                return self.proxmox_api.pools.get(poolid=poolid)
+            else:
+                return self.proxmox_api.pools(poolid).get()
         except Exception as e:
             self.module.fail_json(msg=f"Unable to retrieve pool {poolid} information: {e}")
 

--- a/plugins/modules/proxmox_pool.py
+++ b/plugins/modules/proxmox_pool.py
@@ -81,6 +81,8 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec,
 )
 
+from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
+
 
 class ProxmoxPoolAnsible(ProxmoxAnsible):
     def is_pool_existing(self, poolid):
@@ -135,7 +137,10 @@ class ProxmoxPoolAnsible(ProxmoxAnsible):
                 return
 
             try:
-                self.proxmox_api.pools(poolid).delete()
+                if self.version() >= LooseVersion("8.1"):
+                    self.proxmox_api.pools.delete(poolid=poolid)
+                else:
+                    self.proxmox_api.pools(poolid).delete()
             except Exception as e:
                 self.module.fail_json(msg=f"Failed to delete pool with ID {poolid}: {e}")
         else:

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -112,6 +112,8 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec,
 )
 
+from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
+
 
 class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
     def pool_members(self, poolid):
@@ -149,7 +151,10 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                 if self.module.check_mode:
                     return diff
 
-                self.proxmox_api.pools(poolid).put(storage=[member])
+                if self.version() >= LooseVersion("8.1"):
+                    self.proxmox_api.pools.put(poolid=poolid, storage=[member])
+                else:
+                    self.proxmox_api.pools(poolid).put(storage=[member])
                 return diff
             else:
                 try:
@@ -169,7 +174,10 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                 all_members_after.append(member)
 
                 if not self.module.check_mode:
-                    self.proxmox_api.pools(poolid).put(vms=[vmid])
+                    if self.version() >= LooseVersion("8.1"):
+                        self.proxmox_api.pools.put(poolid=poolid, vms=[vmid])
+                    else:
+                        self.proxmox_api.pools(poolid).put(vms=[vmid])
                 return diff
         except Exception as e:
             self.module.fail_json(msg=f"Failed to add a new member ({member}) to the pool {poolid}: {e}")
@@ -195,7 +203,10 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                 if self.module.check_mode:
                     return diff
 
-                self.proxmox_api.pools(poolid).put(storage=[member], delete=1)
+                if self.version() >= LooseVersion("8.1"):
+                    self.proxmox_api.pools.put(poolid=poolid, storage=[member], delete=1)
+                else:
+                    self.proxmox_api.pools(poolid).put(storage=[member], delete=1)
                 return diff
             else:
                 try:
@@ -215,7 +226,10 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                 all_members_after.remove(vmid)
 
                 if not self.module.check_mode:
-                    self.proxmox_api.pools(poolid).put(vms=[vmid], delete=1)
+                    if self.version() >= LooseVersion("8.1"):
+                        self.proxmox_api.pools.put(poolid=poolid, vms=[vmid], delete=1)
+                    else:
+                        self.proxmox_api.pools(poolid).put(vms=[vmid], delete=1)
                 return diff
         except Exception as e:
             self.module.fail_json(msg=f"Failed to delete a member ({member}) from the pool {poolid}: {e}")


### PR DESCRIPTION
##### SUMMARY

With Proxmox VE 8.1 nested pools got introduced: https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.1
This PR enables support via Ansible while maintaining the old deprecated API for older Proxmox versions.

API reference: https://pve.proxmox.com/pve-docs/api-viewer/#/pools/{poolid}

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- proxmox
- proxmox_pool
- proxmox_pool_member
