### PR TITLE
fix(proxmox_user_info): return empty user list when user not found

### DIFF
--- a/plugins/modules/proxmox_user_info.py
+++ b/plugins/modules/proxmox_user_info.py
@@ -153,6 +153,8 @@ proxmox_users:
 """
 
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
@@ -160,8 +162,6 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
     proxmox_auth_argument_spec,
     proxmox_to_ansible_bool,
 )
-
-import traceback
 
 try:
     import proxmoxer
@@ -171,6 +171,7 @@ except ImportError:
 else:
     PROXMOXER_LIBRARY = True
     PROXMOXER_LIBRARY_IMPORT_ERROR = None
+
 
 class ProxmoxUserInfoAnsible(ProxmoxAnsible):
     def get_user(self, userid):

--- a/tests/unit/plugins/modules/test_proxmox_user_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_user_info.py
@@ -21,9 +21,10 @@ from ansible_collections.community.proxmox.plugins.modules import (
     proxmox_user_info,
 )
 
+
 class TestProxmoxUserInfoModule(ModuleTestCase):
     """Test cases for proxmox_user_info module using ModuleTestCase pattern."""
-    
+
     # Common test data
     BASIC_MODULE_ARGS = {
         "api_host": "test.proxmox.com",
@@ -40,13 +41,7 @@ class TestProxmoxUserInfoModule(ModuleTestCase):
         "firstname": "John",
         "lastname": "Doe",
         "groups": ["admins"],
-        "tokens": [
-            {
-                "expire": 0,
-                "privsep": 0,
-                "tokenid": "test"
-            }
-        ],
+        "tokens": [{"expire": 0, "privsep": 0, "tokenid": "test"}],
         "keys": "",
     }
 
@@ -61,13 +56,7 @@ class TestProxmoxUserInfoModule(ModuleTestCase):
         "firstname": "John",
         "lastname": "Doe",
         "groups": ["admins"],
-        "tokens": [
-            {
-                "expire": 0,
-                "privsep": False,
-                "tokenid": "test"
-            }
-        ],
+        "tokens": [{"expire": 0, "privsep": False, "tokenid": "test"}],
         "keys": "",
     }
 


### PR DESCRIPTION
##### SUMMARY
fix proxmox_user_info returning an error in case the queried user doesn't exist.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
proxmox_user_info

##### ADDITIONAL INFORMATION
Docs already states that `proxmox_user_info` always returns `proxmox_users` but can be empty, with this PR it's now true :)

Also, not finding a user is just an info, quite unexpected to be forced to handle an error in that case, IMHO.

from
```fatal: [localhost]: FAILED! => {"changed": false, "msg": "User 'some-user@pve' does not exist"}```
to
```
ok: [localhost] => {
    "proxmox_user": {
        "changed": false,
        [...]
        "failed": false,
        "proxmox_users": []
    }
}
```