### PR TITLE
feat(kvm): add qemu parameter virtiofs

### DIFF
--- a/changelogs/fragments/336-add-param-virtiofs-on-kvm.yml
+++ b/changelogs/fragments/336-add-param-virtiofs-on-kvm.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_kvm - add qemu parameter ``virtiofs`` (https://github.com/ansible-collections/community.proxmox/pull/336).

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -527,15 +527,15 @@ options:
     description:
       - If V(true), the VM will be updated with new value.
       - Because of the operations of the API and security reasons, I have disabled the update of the following parameters
-        O(net), O(virtio), O(ide), O(sata), O(scsi). Per example updating O(net) update the MAC address and O(virtio) create
+        O(net), O(virtio), O(virtiofs), O(ide), O(sata), O(scsi). Per example updating O(net) update the MAC address and O(virtio) create
         always new disk... This security feature can be disabled by setting the O(update_unsafe) to V(true).
       - Update of O(pool) is disabled. It needs an additional API endpoint not covered by this module.
     type: bool
     default: false
   update_unsafe:
     description:
-      - If V(true), do not enforce limitations on parameters O(net), O(virtio), O(ide), O(sata), O(scsi), O(efidisk0), and
-        O(tpmstate0). Use this option with caution because an improper configuration might result in a permanent loss of data
+      - If V(true), do not enforce limitations on parameters O(net), O(virtio), O(virtiofs), O(ide), O(sata), O(scsi),
+        O(efidisk0), and O(tpmstate0). Use this option with caution because an improper configuration might result in a permanent loss of data
         (for example disk recreated).
     type: bool
     default: false
@@ -558,6 +558,23 @@ options:
       - For a complete list of all available options, please refer to the Proxmox VE documentation (look for "virtio[n]:")
         at U(https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_options).
     type: dict
+  virtiofs:
+    description:
+      - A hash/dictionary of Virtio-fs devices for sharing directories between host and guest.
+      - Keys must be C(virtiofs[n]) where 0 ≤ n ≤ 9.
+      - Values are strings containing comma-separated options. Requires a directory mapping to be created
+        first.
+      - 'Options:'
+      - '  - V(dirid): Identifier of the directory mapping.'
+      - '  - V(cache): Caching policy V(always), V(auto), V(metadata), or V(never).'
+      - '  - V(direct-io): Whether to allow direct I/O. V(0) or V(1).'
+      - '  - V(expose-acl): Whether to expose POSIX ACLs. V(0) or V(1). Implies xattr when enabled.'
+      - '  - V(expose-xattr): Enable support for extended attributes. V(0) or V(1).'
+      - 'Example: V("dirid=my-share,cache=always,direct-io=1,expose-acl=1,expose-xattr=1")'
+      - Available in Proxmox VE 8.4 and later.
+      - For more information, see U(https://pve.proxmox.com/pve-docs/qm.conf.5.html#:~:text=virtiofs,-[n]%3A).
+    type: dict
+
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.
@@ -1077,6 +1094,7 @@ def module_args():
         vcpus=dict(type="int"),
         vga=dict(type="str"),
         virtio=dict(type="dict"),
+        virtiofs=dict(type="dict"),
         vmid=dict(type="int"),
         watchdog=dict(),
         with_local_disks=dict(type="bool", default=False),
@@ -1114,7 +1132,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
         # Convert all dict in kwargs to elements.
-        # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
+        # For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], virtiofs[n]
         for k in list(kwargs.keys()):
             if isinstance(kwargs[k], dict):
                 kwargs.update(kwargs[k])
@@ -1202,7 +1220,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             urlencoded_ssh_keys = quote(kwargs["sshkeys"], safe="")
             kwargs["sshkeys"] = str(urlencoded_ssh_keys)
 
-        # If update, don't update disk (virtio, efidisk0, tpmstate0, ide, sata, scsi) and network interface, unless update_unsafe=True
+        # If update, don't update disk (virtio, efidisk0, tpmstate0, ide, sata, scsi), virtiofs, and network interface, unless update_unsafe=True
         # pool parameter not supported by qemu/<vmid>/config endpoint on "update" (PVE 6.2) - only with "create"
         if update:
             if update_unsafe is False:
@@ -1220,6 +1238,8 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
                     del kwargs["tpmstate0"]
                 if "net" in kwargs:
                     del kwargs["net"]
+                if "virtiofs" in kwargs:
+                    del kwargs["virtiofs"]
             if "force" in kwargs:
                 del kwargs["force"]
             if "pool" in kwargs:
@@ -1252,7 +1272,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             kwargs["tpmstate0"] = f"{tpm.get('storage')}:1,version=v{tpm.get('version')}"
 
         # Convert all dict in kwargs to elements.
-        # For audio[n], hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], ipconfig[n], usb[n]
+        # For audio[n], hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n], virtiofs[n], ipconfig[n], usb[n]
         for k in list(kwargs.keys()):
             if isinstance(kwargs[k], dict):
                 kwargs.update(kwargs[k])
@@ -1593,6 +1613,7 @@ def main():
                 vcpus=module.params["vcpus"],
                 vga=module.params["vga"],
                 virtio=module.params["virtio"],
+                virtiofs=module.params["virtiofs"],
                 watchdog=module.params["watchdog"],
             )
 


### PR DESCRIPTION
##### SUMMARY

Fixes #83

And the qemu parameter `virtiofs` which was added on PVE 8.4.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

`proxmox_kvm`