### PR TITLE
style: fix ruff rule PLR2004

### DIFF
--- a/plugins/module_utils/_filelock.py
+++ b/plugins/module_utils/_filelock.py
@@ -9,7 +9,6 @@
 import fcntl
 import os
 import stat
-import sys
 import time
 from contextlib import contextmanager
 
@@ -57,9 +56,7 @@ class FileLock:
         """
         lock_path = os.path.join(tmpdir, f"ansible-{os.path.basename(path)}.lock")
         l_wait = 0.1
-        r_exception = IOError
-        if sys.version_info[0] == 3:
-            r_exception = BlockingIOError
+        r_exception = BlockingIOError
 
         self.lockfd = open(lock_path, "w")
 

--- a/plugins/module_utils/proxmox_sdn.py
+++ b/plugins/module_utils/proxmox_sdn.py
@@ -20,7 +20,7 @@ class ProxmoxSdnAnsible(ProxmoxAnsible):
         super().__init__(module)
         self.module = module
         pve_major_version = self.version().version[0]
-        self._is_lock_and_rollback_supported = pve_major_version >= 9
+        self._is_lock_and_rollback_supported = pve_major_version >= 9  # noqa: PLR2004
 
     @property
     def is_lock_and_rollback_supported(self) -> bool:

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -809,7 +809,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
         # Resize disk API endpoint has changed at v8.0: PUT method become async.
         version = self.version()
         pve_major_version = 3 if version < LooseVersion("4.0") else version.version[0]
-        if pve_major_version >= 8:
+        if pve_major_version >= 8:  # noqa: PLR2004
             current_task_id = self.proxmox_api.nodes(vm["node"]).qemu(vmid).resize.set(disk=disk, size=size)
             task_success, fail_reason = self.api_task_complete(
                 vm["node"], current_task_id, self.module.params["timeout"]

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1180,19 +1180,19 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         pve_major_version = 3 if version < LooseVersion("4.0") else version.version[0]
 
         # The features work only on PVE 4+
-        if pve_major_version < 4:
+        if pve_major_version < 4:  # noqa: PLR2004
             for p in only_v4:
                 if p in kwargs:
                     del kwargs[p]
 
         # The features work only on PVE 6
-        if pve_major_version < 6:
+        if pve_major_version < 6:  # noqa: PLR2004
             for p in only_v6:
                 if p in kwargs:
                     del kwargs[p]
 
         # The features work only on PVE 8
-        if pve_major_version < 8:
+        if pve_major_version < 8:  # noqa: PLR2004
             for p in only_v8:
                 if p in kwargs:
                     del kwargs[p]

--- a/plugins/modules/proxmox_node_network.py
+++ b/plugins/modules/proxmox_node_network.py
@@ -590,6 +590,12 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
     proxmox_to_ansible_bool,
 )
 
+MIN_VLAN_ID = 1
+MAX_VLAN_ID = 4094
+MAX_BOND_NUMBER = 9999
+MIN_MTU = 1280
+MAX_MTU = 65520
+
 # Single source of truth for all parameter definitions
 PARAMETER_DEFINITIONS = {
     "node": {
@@ -770,7 +776,7 @@ def _is_valid_cidr(cidr):
         return False
     try:
         iface = ip_interface(cidr)
-        return iface.version == 4
+        return iface.version == 4  # noqa: PLR2004
     except Exception:
         return False
 
@@ -781,7 +787,7 @@ def _is_valid_cidr6(cidr):
         return False
     try:
         iface = ip_interface(cidr)
-        return iface.version == 6
+        return iface.version == 6  # noqa: PLR2004
     except Exception:
         return False
 
@@ -791,7 +797,7 @@ def _is_valid_ipv4(addr):
     if not addr:
         return False
     try:
-        return ip_address(addr).version == 4
+        return ip_address(addr).version == 4  # noqa: PLR2004
     except Exception:
         return False
 
@@ -801,7 +807,7 @@ def _is_valid_ipv6(addr):
     if not addr:
         return False
     try:
-        return ip_address(addr).version == 6
+        return ip_address(addr).version == 6  # noqa: PLR2004
     except Exception:
         return False
 
@@ -944,8 +950,8 @@ class ProxmoxNetworkManager(ProxmoxAnsible):
         if mtu_value is not None:
             try:
                 mtu = int(mtu_value)
-                if not (1280 <= mtu <= 65520):
-                    errors.append("mtu must be between 1280 and 65520")
+                if not (MIN_MTU <= mtu <= MAX_MTU):
+                    errors.append(f"mtu must be between {MIN_MTU} and {MAX_MTU}")
             except (ValueError, TypeError):
                 errors.append("mtu must be an integer")
 
@@ -1092,8 +1098,8 @@ class ProxmoxNetworkManager(ProxmoxAnsible):
         if ovs_tag_value is not None:
             try:
                 ovs_tag = int(ovs_tag_value)
-                if not (1 <= ovs_tag <= 4094):
-                    errors.append("ovs_tag must be between 1 and 4094")
+                if not (MIN_VLAN_ID <= ovs_tag <= MAX_VLAN_ID):
+                    errors.append(f"ovs_tag must be between {MIN_VLAN_ID} and {MAX_VLAN_ID}")
             except (ValueError, TypeError):
                 errors.append("ovs_tag must be an integer")
 
@@ -1111,8 +1117,8 @@ class ProxmoxNetworkManager(ProxmoxAnsible):
         if ovs_tag_value is not None:
             try:
                 ovs_tag = int(ovs_tag_value)
-                if not (1 <= ovs_tag <= 4094):
-                    errors.append("ovs_tag must be between 1 and 4094")
+                if not (MIN_VLAN_ID <= ovs_tag <= MAX_VLAN_ID):
+                    errors.append(f"ovs_tag must be between {MIN_VLAN_ID} and {MAX_VLAN_ID}")
             except (ValueError, TypeError):
                 errors.append("ovs_tag must be an integer")
 
@@ -1189,16 +1195,16 @@ class ProxmoxNetworkManager(ProxmoxAnsible):
         if not iface or not iface_type:
             return errors
 
-        # Bond interfaces must follow bondX format (X = 0-9999)
+        # Bond interfaces must follow bondX format (X = 0-MAX_BOND_NUMBER)
         if iface_type in ["bond", "OVSBond"]:
             if not re.match(r"^bond\d{1,5}$", iface):
                 errors.append(
-                    f"Interface name '{iface}' for type '{iface_type}' must follow format 'bondX' where X is a number between 0 and 9999"
+                    f"Interface name '{iface}' for type '{iface_type}' must follow format 'bondX' where X is a number between 0 and {MAX_BOND_NUMBER}"
                 )
             else:
                 bond_number = int(iface[4:])
-                if bond_number > 9999:
-                    errors.append(f"bond interface number must be between 0 and 9999, got {bond_number}")
+                if bond_number > MAX_BOND_NUMBER:
+                    errors.append(f"bond interface number must be between 0 and {MAX_BOND_NUMBER}, got {bond_number}")
 
         # VLAN interfaces support two formats: eth0.100 and vlan100
         elif iface_type == "vlan":
@@ -1212,8 +1218,8 @@ class ProxmoxNetworkManager(ProxmoxAnsible):
                         vlan_id = int(iface[4:])
                     else:
                         vlan_id = int(iface.split(".")[-1])
-                    if not (1 <= vlan_id <= 4094):
-                        errors.append(f"vlan_id must be between 1 and 4094, got {vlan_id}")
+                    if not (MIN_VLAN_ID <= vlan_id <= MAX_VLAN_ID):
+                        errors.append(f"vlan_id must be between {MIN_VLAN_ID} and {MAX_VLAN_ID}, got {vlan_id}")
                 except (ValueError, TypeError):
                     errors.append("vlan_id must be a valid integer")
 

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -197,6 +197,8 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
 )
 
 REQUESTS_TOOLBELT_ERR = None
+MAX_FILE_SIZE_WITHOUT_REQUESTS_TOOLBELT = 256 * 1024 * 1024  # 256 MB
+
 try:
     # requests_toolbelt is used internally by proxmoxer module
     import requests_toolbelt  # noqa: F401, pylint: disable=unused-import
@@ -263,7 +265,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
 
     def upload_template(self, node, storage, content_type, realpath, timeout):
         stats = os.stat(realpath)
-        if stats.st_size > 268435456 and not HAS_REQUESTS_TOOLBELT:
+        if stats.st_size > MAX_FILE_SIZE_WITHOUT_REQUESTS_TOOLBELT and not HAS_REQUESTS_TOOLBELT:
             self.module.fail_json(
                 msg=missing_required_lib("requests_toolbelt", reason="to upload files larger than 256MB"),
                 exception=REQUESTS_TOOLBELT_ERR,

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import os
+import stat
 from contextlib import ExitStack
 from io import StringIO
 from pathlib import Path
@@ -457,7 +458,7 @@ def test_close_with_lock_file(connection):
         assert os.path.exists(lock_file_path), "Lock file was not created"
 
         lock_stat = os.stat(lock_file_path)
-        assert lock_stat.st_mode & 0o777 == 0o600, "Incorrect lock file permissions"
+        assert stat.S_IMODE(lock_stat.st_mode) == (stat.S_IWRITE | stat.S_IREAD), "Incorrect lock file permissions"
     finally:
         Path(lock_file_path).unlink(missing_ok=True)
 

--- a/tests/unit/plugins/modules/test_proxmox_backup.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup.py
@@ -291,7 +291,7 @@ class TestProxmoxBackup(ModuleTestCase):
         for backup_result in result["backups"]:
             assert backup_result["upid"] in {VZDUMP_API_RETURN[key] for key in VZDUMP_API_RETURN}
         assert self.mock_get_taskok.call_count == 0
-        assert self.mock_post_vzdump.call_count == 3
+        assert self.mock_post_vzdump.call_count == len(VZDUMP_API_RETURN)
 
     def test_create_backup_include_mode_with_wait(self):
         with set_module_args(

--- a/tests/unit/plugins/modules/test_proxmox_backup_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_backup_info.py
@@ -225,7 +225,7 @@ class TestProxmoxBackupInfoModule(ModuleTestCase):
 
         result = exc_info.value.args[0]
         assert result["backup_info"] == expected_output
-        assert len(result["backup_info"]) == 2
+        assert len(result["backup_info"]) == len(expected_output)
 
     def test_get_specific_backup_information_by_vmid(self):
         with pytest.raises(AnsibleExitJson) as exc_info:

--- a/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_ha_rules.py
@@ -129,7 +129,7 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
         assert result.get("changed") is True
         assert result.get("rule", {}).get("rule") == "my-rule"
-        assert self.mock_get.call_count == 2
+        assert self.mock_get.call_count == 2  # noqa: PLR2004
         assert self.mock_put.call_count == 0
         assert self.mock_delete.call_count == 0
         self.mock_post.assert_called_once_with(
@@ -198,7 +198,7 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
         assert result.get("changed") is True
         assert result.get("rule", {}).get("rule") == "my-rule"
-        assert self.mock_get.call_count == 2
+        assert self.mock_get.call_count == 2  # noqa: PLR2004
         assert self.mock_put.call_count == 0
         assert self.mock_delete.call_count == 0
         self.mock_post.assert_called_once_with(
@@ -234,7 +234,7 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
         assert result.get("changed") is True
         assert result.get("rule", {}).get("rule") == "my-rule"
-        assert self.mock_get.call_count == 2
+        assert self.mock_get.call_count == 2  # noqa: PLR2004
         assert self.mock_put.call_count == 0
         assert self.mock_delete.call_count == 0
         self.mock_post.assert_called_once_with(
@@ -272,7 +272,7 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
         assert result.get("changed") is True
         assert result.get("rule", {}).get("rule") == "my-rule"
-        assert self.mock_get.call_count == 2
+        assert self.mock_get.call_count == 2  # noqa: PLR2004
         assert self.mock_put.call_count == 0
         assert self.mock_delete.call_count == 0
         self.mock_post.assert_called_once_with(
@@ -485,7 +485,7 @@ class TestProxmoxClusterHARules(ModuleTestCase):
 
         assert result.get("changed") is True
         assert result.get("rule", {}).get("rule") == "my-rule"
-        assert self.mock_get.call_count == 2
+        assert self.mock_get.call_count == 2  # noqa: PLR2004
         assert self.mock_put.call_count == 0
         assert self.mock_delete.call_count == 1
         self.mock_post.assert_called_once_with(

--- a/tests/unit/plugins/modules/test_proxmox_sendkey.py
+++ b/tests/unit/plugins/modules/test_proxmox_sendkey.py
@@ -11,6 +11,8 @@ import pytest
 
 proxmoxer = pytest.importorskip("proxmoxer")
 
+TEST_VMID = 100
+
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
     AnsibleExitJson,
     AnsibleFailJson,
@@ -71,16 +73,16 @@ class TestProxmoxSendkeyModule(ModuleTestCase):
         with self.assertRaises(AnsibleExitJson) as exc_info:
             args = get_module_args_sendkey(name="existing.vm.local", keys_send=["ctrl-alt-delete"])
             with set_module_args(args):
-                self.get_vmid_mock.return_value = 100
+                self.get_vmid_mock.return_value = TEST_VMID
                 self.module.main()
 
         assert self.get_vmid_mock.call_count == 1
         result = exc_info.exception.args[0]
-        assert result["vmid"] == 100
+        assert result["vmid"] == TEST_VMID
 
     def test_sendkey_by_keys_send(self):
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            args = get_module_args_sendkey(vmid=100, keys_send=["ctrl-alt-delete"])
+            args = get_module_args_sendkey(vmid=TEST_VMID, keys_send=["ctrl-alt-delete"])
             with set_module_args(args):
                 self.module.main()
         result = exc_info.exception.args[0]
@@ -88,7 +90,7 @@ class TestProxmoxSendkeyModule(ModuleTestCase):
 
     def test_sendkey_by_string_send(self):
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            args = get_module_args_sendkey(vmid=100, string_send="Hello World!")
+            args = get_module_args_sendkey(vmid=TEST_VMID, string_send="Hello World!")
             with set_module_args(args):
                 self.module.main()
 
@@ -110,20 +112,20 @@ class TestProxmoxSendkeyModule(ModuleTestCase):
 
     def test_fail_when_validate_invalid_keys(self):
         with self.assertRaises(AnsibleFailJson):
-            args = get_module_args_sendkey(vmid=100, keys_send=["invalid"])
+            args = get_module_args_sendkey(vmid=TEST_VMID, keys_send=["invalid"])
             with set_module_args(args):
                 self.module.main()
 
     def test_fail_when_send_invalid_string_char(self):
         with self.assertRaises(AnsibleFailJson):
-            args = get_module_args_sendkey(vmid=100, string_send="ö")
+            args = get_module_args_sendkey(vmid=TEST_VMID, string_send="ö")
             with set_module_args(args):
                 self.module.main()
 
     @patch.object(time, "sleep")
     def test_sleep_key_delay(self, time_sleep_mock):
         with self.assertRaises(AnsibleExitJson) as exc_info:
-            args = get_module_args_sendkey(vmid=100, keys_send=["ctrl-alt-delete"], delay=1.0)
+            args = get_module_args_sendkey(vmid=TEST_VMID, keys_send=["ctrl-alt-delete"], delay=1.0)
             with set_module_args(args):
                 self.module.main()
 

--- a/tests/unit/plugins/modules/test_proxmox_snap_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_snap_info.py
@@ -48,7 +48,7 @@ def test_list_all_snapshots(connect_mock, capfd, mocker):
 
     assert not err
     assert not result.get("failed")
-    assert len(result["snapshots"]) == 3
+    assert len(result["snapshots"]) == len(get_snapshots())
     assert result["snapshots"][1]["name"] == "before-upgrade"
 
 


### PR DESCRIPTION
##### SUMMARY

Fixes the lint rule PLR2004 (27 errors): `Magic value used in comparison, consider replacing 'xx' with a constant variable`