### PR TITLE
fix(cluster_firewall): error message for invalid log_ratelimit rate

### DIFF
--- a/changelogs/fragments/340-proxmox-cluster-firewall-ratelimit-validation.yml
+++ b/changelogs/fragments/340-proxmox-cluster-firewall-ratelimit-validation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_cluster_firewall - error message for invalid log_ratelimit.rate parameter (https://github.com/ansible-collections/community.proxmox/pull/340).

--- a/plugins/modules/proxmox_cluster_firewall.py
+++ b/plugins/modules/proxmox_cluster_firewall.py
@@ -260,7 +260,7 @@ class ProxmoxClusterFirewallAnsible(ProxmoxAnsible):
             return
         lr_rate = lr["rate"]
         if not _validate_log_ratelimit_rate(lr_rate):
-            self.fail_json(
+            self.module.fail_json(
                 msg="log_ratelimit.rate must be a valid rate expression, e.g. '1/second'",
                 rate=lr_rate,
             )


### PR DESCRIPTION
##### SUMMARY

Fixes the ansible error log when `log_ratelimit.rate` is invalid. 

Sorry miss this on my integration tests..

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_cluster_firewall`