### PR TITLE
style: fix ruff rule PLR0913

### DIFF
--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -898,7 +898,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             force=force,
         )
 
-    def lxc_absent(self, vmid, hostname, node, timeout, purge, force):
+    def lxc_absent(self, vmid, hostname, node, timeout, purge, force):  # noqa: PLR0913
         try:
             lxc = self.get_lxc_resource(vmid, hostname)
         except LookupError:
@@ -1077,7 +1077,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
         # update the config
         getattr(proxmox_node, self.VZ_TYPE)(vmid).config.put(vmid=vmid, node=node, **kwargs)
 
-    def new_lxc_instance(self, vmid, hostname, node, clone_from, ostemplate, force):
+    def new_lxc_instance(self, vmid, hostname, node, clone_from, ostemplate, force):  # noqa: PLR0913
         identifier = self.format_vm_identifier(vmid, hostname)
 
         if clone_from is not None:
@@ -1458,7 +1458,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
         return disk_kwargs
 
-    def build_volume(
+    def build_volume(  # noqa: PLR0913
         self,
         vmid,
         node,

--- a/plugins/modules/proxmox_backup.py
+++ b/plugins/modules/proxmox_backup.py
@@ -434,7 +434,7 @@ class ProxmoxBackupAnsible(ProxmoxAnsible):
         tasks.extend(ok_tasks)
         return tasks
 
-    def permission_check(self, storage, mode, node, bandwidth, performance_tweaks, retention, pool, vmids):
+    def permission_check(self, storage, mode, node, bandwidth, performance_tweaks, retention, pool, vmids):  # noqa: PLR0913
         permissions = self._get_permissions()
         self.check_if_storage_exists(storage, node)
         self.check_storage_permissions(permissions, storage, bandwidth, performance_tweaks, retention)

--- a/plugins/modules/proxmox_cluster_ha_groups.py
+++ b/plugins/modules/proxmox_cluster_ha_groups.py
@@ -130,7 +130,7 @@ class ProxmoxClusterHAGroupsAnsible(ProxmoxAnsible):
     def _delete(self, name):
         return self.proxmox_api.cluster.ha.groups(name).delete()
 
-    def create(self, groups, name, comment, nodes, nofailback, restricted):
+    def create(self, groups, name, comment, nodes, nofailback, restricted):  # noqa: PLR0913
         data = {
             "comment": comment,
             "nodes": ",".join(nodes),

--- a/plugins/modules/proxmox_cluster_ha_resources.py
+++ b/plugins/modules/proxmox_cluster_ha_resources.py
@@ -153,7 +153,7 @@ class ProxmoxClusterHAResourcesAnsible(ProxmoxAnsible):
     def _delete(self, sid):
         return self.proxmox_api.cluster.ha.resources(sid).delete()
 
-    def create(self, resources, sid, comment, group, max_relocate, max_restart, state):
+    def create(self, resources, sid, comment, group, max_relocate, max_restart, state):  # noqa: PLR0913
         data = {
             "comment": comment,
             "group": group,

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1170,7 +1170,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             time.sleep(1)
         return False
 
-    def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):
+    def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):  # noqa: PLR0913
         # Available only in PVE 4
         only_v4 = ["force", "protection", "skiplock"]
         only_v6 = ["ciuser", "cipassword", "sshkeys", "ipconfig", "tags"]

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -202,14 +202,14 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
                 mountpoints[key] = value
         return mountpoints
 
-    def _container_mp_disable(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):
+    def _container_mp_disable(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):  # noqa: PLR0913
         # shutdown container if running
         if vmstatus == "running":
             self.shutdown_instance(vm, vmid, timeout)
         # delete all mountpoints configs
         self.vmconfig(vm, vmid).put(delete=" ".join(mountpoints))
 
-    def _container_mp_restore(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):
+    def _container_mp_restore(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):  # noqa: PLR0913
         # NOTE: requires auth as `root@pam`, API tokens are not supported
         # see https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/config
         # restore original config
@@ -254,7 +254,7 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
             for snap in sorted(snapshots, key=lambda x: x["snaptime"])[: len(snapshots) - retention]:
                 self.snapshot(vm, vmid)(snap["name"]).delete()
 
-    def snapshot_create(self, vm, vmid, timeout, snapname, description, vmstate, unbind, retention):
+    def snapshot_create(self, vm, vmid, timeout, snapname, description, vmstate, unbind, retention):  # noqa: PLR0913
         if self.module.check_mode:
             return True
 

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -281,7 +281,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
         except Exception as e:
             self.module.fail_json(msg=f"Uploading template {realpath} failed with error: {e}")
 
-    def fetch_template(self, node, storage, content_type, url, timeout, template):
+    def fetch_template(self, node, storage, content_type, url, timeout, template):  # noqa: PLR0913
         """Fetch a template from a web url source using the proxmox download-url endpoint"""
         try:
             taskid = (
@@ -313,7 +313,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
             time.sleep(1)
         return False
 
-    def fetch_and_verify(self, node, storage, url, content_type, timeout, checksum, checksum_algorithm, template):
+    def fetch_and_verify(self, node, storage, url, content_type, timeout, checksum, checksum_algorithm, template):  # noqa: PLR0913
         """Fetch a template from a web url, then verify it using a checksum."""
         data = {
             "url": url,

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -166,7 +166,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
             else:
                 self.module.fail_json(msg=f"Unable to retrieve user {userid}: {e}")
 
-    def _user_needs_update(self, existing_user, comment, email, enable, expire, firstname, lastname, groups, keys):
+    def _user_needs_update(self, existing_user, comment, email, enable, expire, firstname, lastname, groups, keys):  # noqa: PLR0913
         """Check if user needs updating by comparing current vs desired state"""
         # Check standard fields
         fields = [
@@ -191,7 +191,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
 
         return False
 
-    def create_update_user(
+    def create_update_user(  # noqa: PLR0913
         self,
         userid,
         comment=None,

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -180,9 +180,7 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
         except Exception as e:
             self.module.fail_json(msg=f"Failed to retrieve VMs information from cluster resources: {e}")
 
-    def get_vms_from_nodes(
-        self, cluster_machines, resource_type, vmid=None, name=None, node=None, config=None, network=False
-    ):
+    def get_vms_from_nodes(self, cluster_machines, resource_type, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
         # Leave in dict only machines that user wants to know about
         filtered_vms = {
             vm: info
@@ -223,13 +221,13 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
 
         return filtered_vms
 
-    def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):
+    def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
         try:
             return self.get_vms_from_nodes(cluster_machines, "qemu", vmid, name, node, config, network)
         except Exception as e:
             self.module.fail_json(msg=f"Failed to retrieve QEMU VMs information: {e}")
 
-    def get_lxc_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):
+    def get_lxc_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
         try:
             return self.get_vms_from_nodes(cluster_machines, "lxc", vmid, name, node, config, network)
         except Exception as e:

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -495,7 +495,7 @@ def test_close_lock_file_time_out_error_handling(mock_exists, mock_unlink, conne
 @patch("os.chown")
 @patch("os.rename")
 @patch("os.path.exists")
-def test_tempfile_creation_and_move(
+def test_tempfile_creation_and_move(  # noqa: PLR0913
     mock_exists, mock_rename, mock_chown, mock_chmod, mock_tempfile, mock_lock_file, connection
 ):
     """Test tempfile creation and move during close"""

--- a/tests/unit/plugins/modules/test_proxmox_subnet.py
+++ b/tests/unit/plugins/modules/test_proxmox_subnet.py
@@ -52,7 +52,13 @@ def fail_json(*args, **kwargs):
     raise SystemExit(kwargs)
 
 
-def get_module_args(vnet, subnet, zone, state="present", dhcp_range=None, snat=0, dhcp_range_update_mode="append"):
+def get_module_args(vnet, subnet, zone, **kwargs):
+    defaults = {
+        "state": "present",
+        "dhcp_range": None,
+        "snat": 0,
+        "dhcp_range_update_mode": "append",
+    }
     return {
         "api_host": "host",
         "api_user": "user",
@@ -60,10 +66,8 @@ def get_module_args(vnet, subnet, zone, state="present", dhcp_range=None, snat=0
         "vnet": vnet,
         "subnet": subnet,
         "zone": zone,
-        "state": state,
-        "dhcp_range": dhcp_range,
-        "snat": snat,
-        "dhcp_range_update_mode": dhcp_range_update_mode,
+        **defaults,
+        **kwargs,
     }
 
 


### PR DESCRIPTION
##### SUMMARY

Fixes the lint rule PLR0913 (19 errors): `Too many arguments in function definition (n > 5)`

I ignored most of these errors because fixing it would require more "deep" refactoring. I think it's preferable to just ignore them and address it when implementing new features, fixes, or more deeper refactoring module logic.  And also, this is more like a warnning, current code is still readable.

If you think that these errors should not be ignored but fixed, that's also ok, let me know.