### PR TITLE
style: fix ruff rule D103

### DIFF
--- a/plugins/plugin_utils/unsafe.py
+++ b/plugins/plugin_utils/unsafe.py
@@ -19,6 +19,7 @@ _RE_TEMPLATE_CHARS_BYTES = re.compile(b"[{}]")
 
 
 def make_unsafe(value):
+    """Make a value unsafe."""
     if value is None or isinstance(value, AnsibleUnsafe):
         return value
 


### PR DESCRIPTION
##### SUMMARY

Fixes the lint rule D103 (1 error): `Missing docstring in public function`
