### PR TITLE
style: fix ruff rule UP006

### DIFF
--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -543,7 +543,7 @@ class Connection(ConnectionBase):
         paramiko_preferred_pubkeys = getattr(paramiko.Transport, "_preferred_pubkeys", ())
         paramiko_preferred_hostkeys = getattr(paramiko.Transport, "_preferred_keys", ())
         use_rsa_sha2_algorithms = self.get_option("use_rsa_sha2_algorithms")
-        disabled_algorithms: t.Dict[str, t.Iterable[str]] = {}
+        disabled_algorithms: dict[str, t.Iterable[str]] = {}
         if not use_rsa_sha2_algorithms:
             if paramiko_preferred_pubkeys:
                 disabled_algorithms["pubkeys"] = tuple(a for a in paramiko_preferred_pubkeys if "rsa-sha2" in a)


### PR DESCRIPTION
##### SUMMARY

Fixes the lint rule UP006 (1 error): `Use 'dict' instead of 't.Dict' for type annotation`
