### PR TITLE
style: ruff rule PLR0915

### DIFF
--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -828,7 +828,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
             return True, f"Disk {disk} resized in VM {vmid}"
 
 
-def main():  # noqa: PLR0912
+def main():  # noqa: PLR0912, PLR0915
     module = create_proxmox_module(module_args(), **module_options())
     proxmox = ProxmoxDiskAnsible(module)
 

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -1166,7 +1166,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
             time.sleep(1)
         return False
 
-    def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):  # noqa: PLR0912, PLR0913
+    def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):  # noqa: PLR0912, PLR0913, PLR0915
         # Available only in PVE 4
         only_v4 = ["force", "protection", "skiplock"]
         only_v6 = ["ciuser", "cipassword", "sshkeys", "ipconfig", "tags"]
@@ -1411,7 +1411,7 @@ class ProxmoxKvmAnsible(ProxmoxAnsible):
         return True
 
 
-def main():  # noqa: PLR0912
+def main():  # noqa: PLR0912, PLR0915
     module = create_proxmox_module(module_args(), **module_options())
     proxmox = ProxmoxKvmAnsible(module)
 

--- a/plugins/modules/proxmox_snap.py
+++ b/plugins/modules/proxmox_snap.py
@@ -322,7 +322,7 @@ class ProxmoxSnapAnsible(ProxmoxAnsible):
         return False
 
 
-def main():  # noqa: PLR0912
+def main():  # noqa: PLR0912, PLR0915
     module = create_proxmox_module(module_args(), **module_options())
 
     try:

--- a/plugins/modules/proxmox_subnet.py
+++ b/plugins/modules/proxmox_subnet.py
@@ -247,7 +247,7 @@ class ProxmoxSubnetAnsible(ProxmoxSdnAnsible):
         except Exception as e:
             self.module.fail_json(f"Failed to retrieve subnets {e}")
 
-    def update_subnet(self, **subnet_params):  # noqa: PLR0912
+    def update_subnet(self, **subnet_params):  # noqa: PLR0912, PLR0915
         new_subnet = copy.deepcopy(subnet_params)
         subnet_id = f"{self.params['zone']}-{new_subnet['subnet'].replace('/', '-')}"
         vnet_name = new_subnet["vnet"]

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -329,7 +329,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
             self.module.fail_json(msg=f"Checksum mismatch: {e}")
 
 
-def main():  # noqa: PLR0912
+def main():  # noqa: PLR0912, PLR0915
     module = create_proxmox_module(module_args(), **module_options())
     proxmox = ProxmoxTemplateAnsible(module)
 


### PR DESCRIPTION
##### SUMMARY

This is finally the last one PR about fixing Ruff lint rules :rocket: 

This one "fixes" remaining [PLR0915](https://docs.astral.sh/ruff/rules/too-many-statements/):

```bash
plugins/modules/proxmox_disk.py:831:5: [PLR0915]
  Too many statements (59 > 50)
  ⋮ │ 
830 │ 
831 │ def main():  # noqa: PLR0912
    │     ▔▔▔▔
832 │     module = create_proxmox_module(module_args(), **module_options())
  ⋮ │ 

plugins/modules/proxmox_kvm.py:1169:9: [PLR0915]
  Too many statements (98 > 50)
   ⋮ │ 
1167 │         return False
1168 │ 
1169 │     def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):  # noqa: PLR0912, PLR0913
     │         ▔▔▔▔▔▔▔▔▔
1170 │         # Available only in PVE 4
   ⋮ │ 

plugins/modules/proxmox_kvm.py:1414:5: [PLR0915]
  Too many statements (197 > 50)
   ⋮ │ 
1413 │ 
1414 │ def main():  # noqa: PLR0912
     │     ▔▔▔▔
1415 │     module = create_proxmox_module(module_args(), **module_options())
   ⋮ │ 

plugins/modules/proxmox_snap.py:325:5: [PLR0915]
  Too many statements (62 > 50)
  ⋮ │ 
324 │ 
325 │ def main():  # noqa: PLR0912
    │     ▔▔▔▔
326 │     module = create_proxmox_module(module_args(), **module_options())
  ⋮ │ 

plugins/modules/proxmox_subnet.py:250:9: [PLR0915]
  Too many statements (61 > 50)
  ⋮ │ 
248 │             self.module.fail_json(f"Failed to retrieve subnets {e}")
249 │ 
250 │     def update_subnet(self, **subnet_params):  # noqa: PLR0912
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔
251 │         new_subnet = copy.deepcopy(subnet_params)
  ⋮ │ 

plugins/modules/proxmox_template.py:332:5: [PLR0915]
  Too many statements (52 > 50)
  ⋮ │ 
331 │ 
332 │ def main():  # noqa: PLR0912
    │     ▔▔▔▔
333 │     module = create_proxmox_module(module_args(), **module_options())
  ⋮ │ 
nox > Session codeqa aborted: Ruff check failed.
```
