### PR TITLE
test: add a shared task to setup proxmox auth vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,10 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+# Integration test
+integration_config.yml
+inventory
+
 # Translations
 *.mo
 *.pot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,49 @@ nox -Re ansible-test-units-devel -- --python 3.13
 nox -Re ansible-test-units-devel -- --python 3.13 tests/unit/plugins/modules/test_proxmox_kvm.py
 ```
 
+### Integration tests
+
+Most Proxmox module integration tests require access to a real Proxmox environment and are marked as `unsupported` in CI. This means they are skipped during automated testing and must be executed manually in a properly configured environment.
+
+**Warning:** Integration tests may create, modify, or delete resources on your Proxmox environment. It is strongly recommended to use a dedicated test environment.
+
+#### Setup
+
+1. Create your local configuration file:
+
+   ```bash
+   cp tests/integration/integration_config.yml.template tests/integration/integration_config.yml
+   ```
+
+2. Adjust the authentication variables to match your Proxmox environment. A minimal example configuration may look like:
+
+   ```yaml
+   proxmox_host: https://your-proxmox:8006
+   proxmox_user: root@pam
+   proxmox_password: your-password
+   validate_certs: false
+   ```
+
+   Some modules require the `root@pam` user due to permission constraints.
+
+#### Running tests
+
+You can run integration tests using `ansible-test`:
+
+```bash
+# Run all integration tests
+ansible-test integration -v --allow-unsupported
+
+# Run all integration tests using Docker
+ansible-test integration --docker -v --allow-unsupported
+
+# Run a specific test target
+ansible-test integration proxmox_pool -v --allow-unsupported
+
+# Run a specific test target using Docker
+ansible-test integration proxmox_pool --docker -v --allow-unsupported
+```
+
 ### Manual test and review of changes
 If you want to test your new module or bugfix within a playbook, you may do the following:
 - Ensure your repository resides, for example, in `exampledir/community/proxmox`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -26,3 +26,4 @@ build_ignore:
 # https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
   - .gitignore
   - changelogs/.plugin-cache.yaml
+  - tests/integration/integration_config.yml

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -1,0 +1,10 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+#api_host:
+#api_user:
+#api_password:
+#api_token_id:
+#api_token_secret:
+#validate_certs:

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+proxmoxer >= 2.3.0

--- a/tests/integration/targets/proxmox/meta/main.yml
+++ b/tests/integration/targets/proxmox/meta/main.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+dependencies:
+  - setup_proxmox_auth

--- a/tests/integration/targets/proxmox/tasks/main.yml
+++ b/tests/integration/targets/proxmox/tasks/main.yml
@@ -7,610 +7,448 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: List domains
-  proxmox_domain_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-  register: results
+- name: Test
+  environment: "{{ environment_auth_vars }}"
 
-- assert:
-    that:
-    - results is not changed
-    - results.proxmox_domains is defined
-
-- name: Retrieve info about pve
-  proxmox_domain_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-    domain: pve
-  register: results
-
-- assert:
-    that:
-    - results is not changed
-    - results.proxmox_domains is defined
-    - results.proxmox_domains|length == 1
-    - results.proxmox_domains[0].type == 'pve'
-
-- name: List groups
-  proxmox_group_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-  register: results
-
-- assert:
-    that:
-    - results is not changed
-    - results.proxmox_groups is defined
-
-- name: List users
-  proxmox_user_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-  register: results
-
-- assert:
-    that:
-    - results is not changed
-    - results.proxmox_users is defined
-
-- name: Retrieve info about api_user using name and domain
-  proxmox_user_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-    user: "{{ user }}"
-    domain: "{{ domain }}"
-  register: results_user_domain
-
-- assert:
-    that:
-    - results_user_domain is not changed
-    - results_user_domain.proxmox_users is defined
-    - results_user_domain.proxmox_users|length == 1
-    - results_user_domain.proxmox_users[0].domain == "{{ domain }}"
-    - results_user_domain.proxmox_users[0].user == "{{ user }}"
-    - results_user_domain.proxmox_users[0].userid == "{{ user }}@{{ domain }}"
-
-- name: Retrieve info about api_user using userid
-  proxmox_user_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-    userid: "{{ user }}@{{ domain }}"
-  register: results_userid
-
-- assert:
-    that:
-    - results_userid is not changed
-    - results_userid.proxmox_users is defined
-    - results_userid.proxmox_users|length == 1
-    - results_userid.proxmox_users[0].domain == "{{ domain }}"
-    - results_userid.proxmox_users[0].user == "{{ user }}"
-    - results_userid.proxmox_users[0].userid == "{{ user }}@{{ domain }}"
-
-- name: Retrieve info about storage
-  proxmox_storage_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-    storage: "{{ storage }}"
-  register: results_storage
-
-- assert:
-    that:
-    - results_storage is not changed
-    - results_storage.proxmox_storages is defined
-    - results_storage.proxmox_storages|length == 1
-    - results_storage.proxmox_storages[0].storage == "{{ storage }}"
-
-- name: List content on storage
-  proxmox_storage_contents_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-    storage: "{{ storage }}"
-    node: "{{ node }}"
-    content: images
-  register: results_list_storage
-
-- assert:
-    that:
-    - results_storage is not changed
-    - results_storage.proxmox_storage_content is defined
-    - results_storage.proxmox_storage_content |length == 1
-
-- name: VM creation
-  tags: [ 'create' ]
   block:
-    - name: Create test vm test-instance
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
+    - name: List domains
+      proxmox_domain_info:
+      register: results
+
+    - assert:
+        that:
+          - results is not changed
+          - results.proxmox_domains is defined
+
+    - name: Retrieve info about pve
+      proxmox_domain_info:
+        domain: pve
+      register: results
+
+    - assert:
+        that:
+          - results is not changed
+          - results.proxmox_domains is defined
+          - results.proxmox_domains|length == 1
+          - results.proxmox_domains[0].type == 'pve'
+
+    - name: List groups
+      proxmox_group_info:
+      register: results
+
+    - assert:
+        that:
+          - results is not changed
+          - results.proxmox_groups is defined
+
+    - name: List users
+      proxmox_user_info:
+      register: results
+
+    - assert:
+        that:
+          - results is not changed
+          - results.proxmox_users is defined
+
+    - name: Retrieve info about api_user using name and domain
+      proxmox_user_info:
+        user: "{{ user }}"
+        domain: "{{ domain }}"
+      register: results_user_domain
+
+    - assert:
+        that:
+          - results_user_domain is not changed
+          - results_user_domain.proxmox_users is defined
+          - results_user_domain.proxmox_users|length == 1
+          - results_user_domain.proxmox_users[0].domain == "{{ domain }}"
+          - results_user_domain.proxmox_users[0].user == "{{ user }}"
+          - results_user_domain.proxmox_users[0].userid == "{{ user }}@{{ domain }}"
+
+    - name: Retrieve info about api_user using userid
+      proxmox_user_info:
+        userid: "{{ user }}@{{ domain }}"
+      register: results_userid
+
+    - assert:
+        that:
+          - results_userid is not changed
+          - results_userid.proxmox_users is defined
+          - results_userid.proxmox_users|length == 1
+          - results_userid.proxmox_users[0].domain == "{{ domain }}"
+          - results_userid.proxmox_users[0].user == "{{ user }}"
+          - results_userid.proxmox_users[0].userid == "{{ user }}@{{ domain }}"
+
+    - name: Retrieve info about storage
+      proxmox_storage_info:
         storage: "{{ storage }}"
-        vmid: "{{ from_vmid }}"
-        name: test-instance
-        clone: 'yes'
-        state: present
-        tags:
-          - TagWithUppercaseChars
-        timeout: 500
-      register: results_kvm
-
-    - set_fact:
-        vmid: "{{ results_kvm.msg.split(' ')[-7] }}"
+      register: results_storage
 
     - assert:
         that:
-        - results_kvm is changed
-        - results_kvm.vmid == from_vmid
-        - results_kvm.msg == "VM test-instance with newid {{ vmid }} cloned from vm with vmid {{ from_vmid }}"
+          - results_storage is not changed
+          - results_storage.proxmox_storages is defined
+          - results_storage.proxmox_storages|length == 1
+          - results_storage.proxmox_storages[0].storage == "{{ storage }}"
 
-    - pause:
-        seconds: 30
-
-- name: VM start
-  tags: [ 'start' ]
-  block:
-    - name: Start test VM
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
+    - name: List content on storage
+      proxmox_storage_contents_info:
+        storage: "{{ storage }}"
         node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: started
-      register: results_action_start
+        content: images
+      register: results_list_storage
 
     - assert:
         that:
-        - results_action_start is changed
-        - results_action_start.status == 'stopped'
-        - results_action_start.vmid == {{ vmid }}
-        - results_action_start.msg == "VM {{ vmid }} started"
+          - results_storage is not changed
+          - results_storage.proxmox_storage_content is defined
+          - results_storage.proxmox_storage_content |length == 1
 
-    - pause:
-        seconds: 90
+    - name: VM creation
+      tags: ["create"]
+      block:
+        - name: Create test vm test-instance
+          proxmox_kvm:
+            node: "{{ node }}"
+            storage: "{{ storage }}"
+            vmid: "{{ from_vmid }}"
+            name: test-instance
+            clone: "yes"
+            state: present
+            tags:
+              - TagWithUppercaseChars
+            timeout: 500
+          register: results_kvm
 
-    - name: Try to start test VM again
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: started
-      register: results_action_start_again
+        - set_fact:
+            vmid: "{{ results_kvm.msg.split(' ')[-7] }}"
 
-    - assert:
-        that:
-        - results_action_start_again is not changed
-        - results_action_start_again.status == 'running'
-        - results_action_start_again.vmid == {{ vmid }}
-        - results_action_start_again.msg == "VM {{ vmid }} is already running"
+        - assert:
+            that:
+              - results_kvm is changed
+              - results_kvm.vmid == from_vmid
+              - results_kvm.msg == "VM test-instance with newid {{ vmid }} cloned from vm with vmid {{ from_vmid }}"
 
-    - name: Check current status
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: current
-      register: results_action_current
+        - pause:
+            seconds: 30
 
-    - assert:
-        that:
-        - results_action_current is not changed
-        - results_action_current.status == 'running'
-        - results_action_current.vmid == {{ vmid }}
-        - results_action_current.msg == "VM test-instance with vmid = {{ vmid }} is running"
+    - name: VM start
+      tags: ["start"]
+      block:
+        - name: Start test VM
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: started
+          register: results_action_start
 
-- name: VM add/change/delete NIC
-  tags: [ 'nic' ]
-  block:
-    - name: Add NIC to test VM
-      proxmox_nic:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        vmid: "{{ vmid }}"
-        state: present
-        interface: net5
-        bridge: vmbr0
-        tag: 42
+        - assert:
+            that:
+              - results_action_start is changed
+              - results_action_start.status == 'stopped'
+              - results_action_start.vmid == {{ vmid }}
+              - results_action_start.msg == "VM {{ vmid }} started"
+
+        - pause:
+            seconds: 90
+
+        - name: Try to start test VM again
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: started
+          register: results_action_start_again
+
+        - assert:
+            that:
+              - results_action_start_again is not changed
+              - results_action_start_again.status == 'running'
+              - results_action_start_again.vmid == {{ vmid }}
+              - results_action_start_again.msg == "VM {{ vmid }} is already running"
+
+        - name: Check current status
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: current
+          register: results_action_current
+
+        - assert:
+            that:
+              - results_action_current is not changed
+              - results_action_current.status == 'running'
+              - results_action_current.vmid == {{ vmid }}
+              - results_action_current.msg == "VM test-instance with vmid = {{ vmid }} is running"
+
+    - name: VM add/change/delete NIC
+      tags: ["nic"]
+      block:
+        - name: Add NIC to test VM
+          proxmox_nic:
+            vmid: "{{ vmid }}"
+            state: present
+            interface: net5
+            bridge: vmbr0
+            tag: 42
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
+
+        - name: Update NIC no changes
+          proxmox_nic:
+            vmid: "{{ vmid }}"
+            state: present
+            interface: net5
+            bridge: vmbr0
+            tag: 42
+          register: results
+
+        - assert:
+            that:
+              - results is not changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Nic net5 unchanged on VM with vmid {{ vmid }}"
+
+        - name: Update NIC with changes
+          proxmox_nic:
+            vmid: "{{ vmid }}"
+            state: present
+            interface: net5
+            bridge: vmbr0
+            tag: 24
+            firewall: true
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
+
+        - name: Delete NIC
+          proxmox_nic:
+            vmid: "{{ vmid }}"
+            state: absent
+            interface: net5
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Nic net5 deleted on VM with vmid {{ vmid }}"
+
+    - name: Create new disk in VM
+      tags: ["create_disk"]
+      block:
+        - name: Add new disk (without force) to VM
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            storage: "{{ storage }}"
+            size: 1
+            state: present
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
+
+        - name: Try add disk again with same options (expect no-op)
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            storage: "{{ storage }}"
+            size: 1
+            state: present
+          register: results
+
+        - assert:
+            that:
+              - results is not changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} is up to date in VM {{ vmid }}"
+
+        - name: Add new disk replacing existing disk (detach old and leave unused)
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            storage: "{{ storage }}"
+            size: 2
+            create: forced
+            state: present
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
+
+    - name: Update existing disk in VM
+      tags: ["update_disk"]
+      block:
+        - name: Update disk configuration
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            backup: false
+            ro: true
+            aio: native
+            state: present
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} updated in VM {{ vmid }}"
+
+    - name: Grow existing disk in VM
+      tags: ["grow_disk"]
+      block:
+        - name: Increase disk size
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            size: +1G
+            state: resized
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} resized in VM {{ vmid }}"
+
+    - name: Detach disk and leave it unused
+      tags: ["detach_disk"]
+      block:
+        - name: Detach disk
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            state: detached
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} detached from VM {{ vmid }}"
+
+    - name: Move disk to another storage or another VM
+      tags: ["move_disk"]
+      block:
+        - name: Move disk to another storage inside same VM
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            target_storage: "{{ target_storage }}"
+            format: "{{ target_format }}"
+            state: moved
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
+
+        - name: Move disk to another VM (same storage)
+          proxmox_disk:
+            vmid: "{{ vmid }}"
+            disk: "{{ disk }}"
+            target_vmid: "{{ target_vm }}"
+            target_disk: "{{ target_disk }}"
+            state: moved
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ vmid }}
+              - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
+
+    - name: Remove disk permanently
+      tags: ["remove_disk"]
+      block:
+        - name: Remove disk
+          proxmox_disk:
+            vmid: "{{ target_vm }}"
+            disk: "{{ target_disk }}"
+            state: absent
+          register: results
+
+        - assert:
+            that:
+              - results is changed
+              - results.vmid == {{ target_vm }}
+              - results.msg == "Disk {{ target_disk }} removed from VM {{ target_vm }}"
+
+    - name: VM stop
+      tags: ["stop"]
+      block:
+        - name: Stop test VM
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: stopped
+          register: results_action_stop
+
+        - assert:
+            that:
+              - results_action_stop is changed
+              - results_action_stop.status == 'running'
+              - results_action_stop.vmid == {{ vmid }}
+              - results_action_stop.msg == "VM {{ vmid }} is shutting down"
+
+        - pause:
+            seconds: 5
+
+        - name: Check current status again
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: current
+          register: results_action_current
+
+        - assert:
+            that:
+              - results_action_current is not changed
+              - results_action_current.status == 'stopped'
+              - results_action_current.vmid == {{ vmid }}
+              - results_action_current.msg == "VM test-instance with vmid = {{  vmid }} is stopped"
+
+    - name: VM destroy
+      tags: ["destroy"]
+      block:
+        - name: Destroy test VM
+          proxmox_kvm:
+            node: "{{ node }}"
+            vmid: "{{ vmid }}"
+            state: absent
+          register: results_kvm_destroy
+
+        - assert:
+            that:
+              - results_kvm_destroy is changed
+              - results_kvm_destroy.vmid == {{ vmid }}
+              - results_kvm_destroy.msg == "VM {{ vmid }} removed"
+
+    - name: Retrieve information about nodes
+      proxmox_node_info:
       register: results
 
     - assert:
         that:
-        - results is changed
-        - results.vmid == {{ vmid }}
-        - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
-
-    - name: Update NIC no changes
-      proxmox_nic:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        vmid: "{{ vmid }}"
-        state: present
-        interface: net5
-        bridge: vmbr0
-        tag: 42
-      register: results
-
-    - assert:
-        that:
-        - results is not changed
-        - results.vmid == {{ vmid }}
-        - results.msg == "Nic net5 unchanged on VM with vmid {{ vmid }}"
-
-    - name: Update NIC with changes
-      proxmox_nic:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        vmid: "{{ vmid }}"
-        state: present
-        interface: net5
-        bridge: vmbr0
-        tag: 24
-        firewall: true
-      register: results
-
-    - assert:
-        that:
-        - results is changed
-        - results.vmid == {{ vmid }}
-        - results.msg == "Nic net5 updated on VM with vmid {{ vmid }}"
-
-    - name: Delete NIC
-      proxmox_nic:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        vmid: "{{ vmid }}"
-        state: absent
-        interface: net5
-      register: results
-
-    - assert:
-        that:
-        - results is changed
-        - results.vmid == {{ vmid }}
-        - results.msg == "Nic net5 deleted on VM with vmid {{ vmid }}"
-
-- name: Create new disk in VM
-  tags: ['create_disk']
-  block:
-  - name: Add new disk (without force) to VM
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      storage: "{{ storage }}"
-      size: 1
-      state: present
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
-
-  - name: Try add disk again with same options (expect no-op)
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      storage: "{{ storage }}"
-      size: 1
-      state: present
-    register: results
-
-  - assert:
-      that:
-      - results is not changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} is up to date in VM {{ vmid }}"
-
-  - name: Add new disk replacing existing disk (detach old and leave unused)
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      storage: "{{ storage }}"
-      size: 2
-      create: forced
-      state: present
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} created in VM {{ vmid }}"
-
-- name: Update existing disk in VM
-  tags: ['update_disk']
-  block:
-  - name: Update disk configuration
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      backup: false
-      ro: true
-      aio: native
-      state: present
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} updated in VM {{ vmid }}"
-
-- name: Grow existing disk in VM
-  tags: ['grow_disk']
-  block:
-  - name: Increase disk size
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      size: +1G
-      state: resized
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} resized in VM {{ vmid }}"
-
-- name: Detach disk and leave it unused
-  tags: ['detach_disk']
-  block:
-  - name: Detach disk
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      state: detached
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} detached from VM {{ vmid }}"
-
-- name: Move disk to another storage or another VM
-  tags: ['move_disk']
-  block:
-  - name: Move disk to another storage inside same VM
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      target_storage: "{{ target_storage }}"
-      format: "{{ target_format }}"
-      state: moved
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
-
-  - name: Move disk to another VM (same storage)
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ vmid }}"
-      disk: "{{ disk }}"
-      target_vmid: "{{ target_vm }}"
-      target_disk: "{{ target_disk }}"
-      state: moved
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ vmid }}
-      - results.msg == "Disk {{ disk }} moved from VM {{ vmid }} storage {{ results.storage }}"
-
-
-- name: Remove disk permanently
-  tags: ['remove_disk']
-  block:
-  - name: Remove disk
-    proxmox_disk:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      vmid: "{{ target_vm }}"
-      disk: "{{ target_disk }}"
-      state: absent
-    register: results
-
-  - assert:
-      that:
-      - results is changed
-      - results.vmid == {{ target_vm }}
-      - results.msg == "Disk {{ target_disk }} removed from VM {{ target_vm }}"
-
-- name: VM stop
-  tags: [ 'stop' ]
-  block:
-    - name: Stop test VM
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: stopped
-      register: results_action_stop
-
-    - assert:
-        that:
-        - results_action_stop is changed
-        - results_action_stop.status == 'running'
-        - results_action_stop.vmid == {{ vmid }}
-        - results_action_stop.msg == "VM {{ vmid }} is shutting down"
-
-    - pause:
-        seconds: 5
-
-    - name: Check current status again
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: current
-      register: results_action_current
-
-    - assert:
-        that:
-        - results_action_current is not changed
-        - results_action_current.status == 'stopped'
-        - results_action_current.vmid == {{ vmid }}
-        - results_action_current.msg == "VM test-instance with vmid = {{  vmid }} is stopped"
-
-- name: VM destroy
-  tags: [ 'destroy' ]
-  block:
-    - name: Destroy test VM
-      proxmox_kvm:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
-        node: "{{ node }}"
-        vmid: "{{ vmid }}"
-        state: absent
-      register: results_kvm_destroy
-
-    - assert:
-        that:
-        - results_kvm_destroy is changed
-        - results_kvm_destroy.vmid == {{ vmid }}
-        - results_kvm_destroy.msg == "VM {{ vmid }} removed"
-
-- name: Retrieve information about nodes
-  proxmox_node_info:
-    api_host: "{{ api_host }}"
-    api_user: "{{ user }}@{{ domain }}"
-    api_password: "{{ api_password | default(omit) }}"
-    api_token_id: "{{ api_token_id | default(omit) }}"
-    api_token_secret: "{{ api_token_secret | default(omit) }}"
-    validate_certs: "{{ validate_certs }}"
-  register: results
-
-- assert:
-    that:
-    - results is not changed
-    - results.proxmox_nodes is defined
-    - results.proxmox_nodes|length >= 1
-    - results.proxmox_nodes[0].type == 'node'
+          - results is not changed
+          - results.proxmox_nodes is defined
+          - results.proxmox_nodes|length >= 1
+          - results.proxmox_nodes[0].type == 'node'

--- a/tests/integration/targets/proxmox_pool/meta/main.yml
+++ b/tests/integration/targets/proxmox_pool/meta/main.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+dependencies:
+  - setup_proxmox_auth

--- a/tests/integration/targets/proxmox_pool/tasks/main.yml
+++ b/tests/integration/targets/proxmox_pool/tasks/main.yml
@@ -9,212 +9,142 @@
 
 - name: Proxmox VE pool and pool membership management
   tags: ["pool"]
+  environment: "{{ environment_auth_vars }}"
+
   block:
-  - name: Make sure poolid parameter is not missing
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-    ignore_errors: true
-    register: result
+    - name: Make sure poolid parameter is not missing
+      proxmox_pool:
+      ignore_errors: true
+      register: result
 
-  - assert:
-      that:
-        - result is failed
-        - "'missing required arguments: poolid' in result.msg"
+    - assert:
+        that:
+          - result is failed
+          - "'missing required arguments: poolid' in result.msg"
 
-  - name: Create pool (Check)
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-      poolid: "{{ poolid }}"
-    check_mode: true
-    register: result
+    - name: Create pool (Check)
+      proxmox_pool:
+        poolid: "{{ poolid }}"
+      check_mode: true
+      register: result
 
-  - assert:
-      that:
-        - result is changed
-        - result is success
+    - assert:
+        that:
+          - result is changed
+          - result is success
 
-  - name: Create pool
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-      poolid: "{{ poolid }}"
-    register: result
+    - name: Create pool
+      proxmox_pool:
+        poolid: "{{ poolid }}"
+      register: result
 
-  - assert:
-      that:
-        - result is changed
-        - result is success
-        - result.poolid == "{{ poolid }}"
+    - assert:
+        that:
+          - result is changed
+          - result is success
+          - result.poolid == "{{ poolid }}"
 
-  - name: Delete pool (Check)
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-      poolid: "{{ poolid }}"
-      state: absent
-    check_mode: true
-    register: result
+    - name: Delete pool (Check)
+      proxmox_pool:
+        poolid: "{{ poolid }}"
+        state: absent
+      check_mode: true
+      register: result
 
-  - assert:
-      that:
-        - result is changed
-        - result is success
+    - assert:
+        that:
+          - result is changed
+          - result is success
 
-  - name: Delete non-existing pool should do nothing
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-      poolid: "non-existing-poolid"
-      state: absent
-    register: result
+    - name: Delete non-existing pool should do nothing
+      proxmox_pool:
+        poolid: "non-existing-poolid"
+        state: absent
+      register: result
 
-  - assert:
-      that:
-        - result is not changed
-        - result is success
+    - assert:
+        that:
+          - result is not changed
+          - result is success
 
-  - name: Deletion of non-empty pool fails
-    block:
-      - name: Add storage into pool
-        proxmox_pool_member:
-          api_host: "{{ api_host }}"
-          api_user: "{{ user }}@{{ domain }}"
-          api_password: "{{ api_password | default(omit) }}"
-          api_token_id: "{{ api_token_id | default(omit) }}"
-          api_token_secret: "{{ api_token_secret | default(omit) }}"
-          validate_certs: "{{ validate_certs }}"
-          poolid: "{{ poolid }}"
-          member: "{{ member }}"
-          type: "{{ member_type }}"
-        diff: true
-        register: result
+    - name: Deletion of non-empty pool fails
+      block:
+        - name: Add storage into pool
+          proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            member: "{{ member }}"
+            type: "{{ member_type }}"
+          diff: true
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - result is success
-            - "'{{ member }}' in result.diff.after.members"
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "'{{ member }}' in result.diff.after.members"
 
-      - name: Add non-existing storage into pool should fail
-        proxmox_pool_member:
-          api_host: "{{ api_host }}"
-          api_user: "{{ user }}@{{ domain }}"
-          api_password: "{{ api_password | default(omit) }}"
-          api_token_id: "{{ api_token_id | default(omit) }}"
-          api_token_secret: "{{ api_token_secret | default(omit) }}"
-          validate_certs: "{{ validate_certs }}"
-          poolid: "{{ poolid }}"
-          member: "non-existing-storage"
-          type: "{{ member_type }}"
-        ignore_errors: true
-        register: result
+        - name: Add non-existing storage into pool should fail
+          proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            member: "non-existing-storage"
+            type: "{{ member_type }}"
+          ignore_errors: true
+          register: result
 
-      - assert:
-          that:
-            - result is failed
-            - "'Storage non-existing-storage doesn\\'t exist in the cluster' in result.msg"
+        - assert:
+            that:
+              - result is failed
+              - "'Storage non-existing-storage doesn\\'t exist in the cluster' in result.msg"
 
-      - name: Delete non-empty pool
-        proxmox_pool:
-          api_host: "{{ api_host }}"
-          api_user: "{{ user }}@{{ domain }}"
-          api_password: "{{ api_password | default(omit) }}"
-          api_token_id: "{{ api_token_id | default(omit) }}"
-          api_token_secret: "{{ api_token_secret | default(omit) }}"
-          validate_certs: "{{ validate_certs }}"
-          poolid: "{{ poolid }}"
-          state: absent
-        ignore_errors: true
-        register: result
+        - name: Delete non-empty pool
+          proxmox_pool:
+            poolid: "{{ poolid }}"
+            state: absent
+          ignore_errors: true
+          register: result
 
-      - assert:
-          that:
-            - result is failed
-            - "'Please remove members from pool first.' in result.msg"
+        - assert:
+            that:
+              - result is failed
+              - "'Please remove members from pool first.' in result.msg"
 
-      - name: Delete storage from the pool
-        proxmox_pool_member:
-          api_host: "{{ api_host }}"
-          api_user: "{{ user }}@{{ domain }}"
-          api_password: "{{ api_password | default(omit) }}"
-          api_token_id: "{{ api_token_id | default(omit) }}"
-          api_token_secret: "{{ api_token_secret | default(omit) }}"
-          validate_certs: "{{ validate_certs }}"
-          poolid: "{{ poolid }}"
-          member: "{{ member }}"
-          type: "{{ member_type }}"
-          state: absent
-        register: result
+        - name: Delete storage from the pool
+          proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            member: "{{ member }}"
+            type: "{{ member_type }}"
+            state: absent
+          register: result
 
-      - assert:
-          that:
-            - result is success
-            - result is changed
+        - assert:
+            that:
+              - result is success
+              - result is changed
 
-    rescue:
-      - name: Delete storage from the pool if it is added
-        proxmox_pool_member:
-          api_host: "{{ api_host }}"
-          api_user: "{{ user }}@{{ domain }}"
-          api_password: "{{ api_password | default(omit) }}"
-          api_token_id: "{{ api_token_id | default(omit) }}"
-          api_token_secret: "{{ api_token_secret | default(omit) }}"
-          validate_certs: "{{ validate_certs }}"
-          poolid: "{{ poolid }}"
-          member: "{{ member }}"
-          type: "{{ member_type }}"
-          state: absent
-        ignore_errors: true
+      rescue:
+        - name: Delete storage from the pool if it is added
+          proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            member: "{{ member }}"
+            type: "{{ member_type }}"
+            state: absent
+          ignore_errors: true
 
-  - name: Delete pool
-    proxmox_pool:
-      api_host: "{{ api_host }}"
-      api_user: "{{ user }}@{{ domain }}"
-      api_password: "{{ api_password | default(omit) }}"
-      api_token_id: "{{ api_token_id | default(omit) }}"
-      api_token_secret: "{{ api_token_secret | default(omit) }}"
-      validate_certs: "{{ validate_certs }}"
-      poolid: "{{ poolid }}"
-      state: absent
-    register: result
+    - name: Delete pool
+      proxmox_pool:
+        poolid: "{{ poolid }}"
+        state: absent
+      register: result
 
-  - assert:
-      that:
-        - result is changed
-        - result is success
-        - result.poolid == "{{ poolid }}"
+    - assert:
+        that:
+          - result is changed
+          - result is success
+          - result.poolid == "{{ poolid }}"
 
   rescue:
     - name: Delete test pool if it is created
       proxmox_pool:
-        api_host: "{{ api_host }}"
-        api_user: "{{ user }}@{{ domain }}"
-        api_password: "{{ api_password | default(omit) }}"
-        api_token_id: "{{ api_token_id | default(omit) }}"
-        api_token_secret: "{{ api_token_secret | default(omit) }}"
-        validate_certs: "{{ validate_certs }}"
         poolid: "{{ poolid }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/proxmox_template/meta/main.yml
+++ b/tests/integration/targets/proxmox_template/meta/main.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+dependencies:
+  - setup_proxmox_auth

--- a/tests/integration/targets/proxmox_template/tasks/main.yml
+++ b/tests/integration/targets/proxmox_template/tasks/main.yml
@@ -9,8 +9,10 @@
 
 - name: Proxmox VE virtual machines templates management
   tags: ['template']
+  environment: "{{ environment_auth_vars }}"
   vars:
     filename: /tmp/dummy.iso
+
   block:
     - name: Create dummy ISO file
       ansible.builtin.command:
@@ -28,12 +30,6 @@
 
     - name: Upload ISO as template to Proxmox VE cluster should fail
       proxmox_template:
-        api_host: '{{ api_host }}'
-        api_user: '{{ user }}@{{ domain }}'
-        api_password: '{{ api_password | default(omit) }}'
-        api_token_id: '{{ api_token_id | default(omit) }}'
-        api_token_secret: '{{ api_token_secret | default(omit) }}'
-        validate_certs: '{{ validate_certs }}'
         node: '{{ node }}'
         src: '{{ filename }}'
         content_type: iso
@@ -53,12 +49,6 @@
 
     - name: Upload ISO as template to Proxmox VE cluster should be successful
       proxmox_template:
-        api_host: '{{ api_host }}'
-        api_user: '{{ user }}@{{ domain }}'
-        api_password: '{{ api_password | default(omit) }}'
-        api_token_id: '{{ api_token_id | default(omit) }}'
-        api_token_secret: '{{ api_token_secret | default(omit) }}'
-        validate_certs: '{{ validate_certs }}'
         node: '{{ node }}'
         src: '{{ filename }}'
         content_type: iso
@@ -82,12 +72,6 @@
 
     - name: Upload ISO as template to Proxmox VE cluster should be successful
       proxmox_template:
-        api_host: '{{ api_host }}'
-        api_user: '{{ user }}@{{ domain }}'
-        api_password: '{{ api_password | default(omit) }}'
-        api_token_id: '{{ api_token_id | default(omit) }}'
-        api_token_secret: '{{ api_token_secret | default(omit) }}'
-        validate_certs: '{{ validate_certs }}'
         node: '{{ node }}'
         src: '{{ filename }}'
         content_type: iso
@@ -111,12 +95,6 @@
 
     - name: Upload ISO as template to Proxmox VE cluster should be successful
       proxmox_template:
-        api_host: '{{ api_host }}'
-        api_user: '{{ user }}@{{ domain }}'
-        api_password: '{{ api_password | default(omit) }}'
-        api_token_id: '{{ api_token_id | default(omit) }}'
-        api_token_secret: '{{ api_token_secret | default(omit) }}'
-        validate_certs: '{{ validate_certs }}'
         node: '{{ node }}'
         src: '{{ filename }}'
         content_type: iso

--- a/tests/integration/targets/setup_proxmox_auth/tasks/main.yml
+++ b/tests/integration/targets/setup_proxmox_auth/tasks/main.yml
@@ -1,0 +1,13 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+- name: Set Proxmox authentification global environment variables
+  ansible.builtin.set_fact:
+    environment_auth_vars:
+      PROXMOX_HOST: "{{ api_host }}"
+      PROXMOX_USER: "{{ api_user | default(omit)}}"
+      PROXMOX_PASSWORD: "{{ api_password | default(omit) }}"
+      PROXMOX_VALIDATE_CERTS: "{{ validate_certs | default(omit) }}"
+      PROXMOX_TOKEN_ID: "{{ api_token_id | default(omit) }}"
+      PROXMOX_TOKEN_SECRET: "{{ api_token_secret | default(omit) }}"


### PR DESCRIPTION
##### SUMMARY

Simplify the configuration of Proxmox authentication for integration tests by adding a helper that sets env vars from a config file.

I haven't touched the existing integration tests yet, but I'm planning to. I was wondering how to avoid passing auth options on each task.

Not sure if this is the way to go. I'm quite new to this domain I found this pattern from the VMware collection.

Open to any ideas or thoughts, would really like to work on integration tests to make us more confident about changes.