### PR TITLE
fix: get storages invalid type kwarg

### DIFF
--- a/changelogs/fragments/401-fix-get-storages-invalid-type-kwarg.yml
+++ b/changelogs/fragments/401-fix-get-storages-invalid-type-kwarg.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox modules - fix calls to ``get_storages()`` to use the correct keyword argument (https://github.com/ansible-collections/community.proxmox/pull/401).

--- a/plugins/modules/proxmox_backup.py
+++ b/plugins/modules/proxmox_backup.py
@@ -342,7 +342,7 @@ class ProxmoxBackupAnsible(ProxmoxAnsible):
             self.module.fail_json(changed=False, msg="Insufficient permissions: You dont have the VM.Backup permission")
 
     def check_if_storage_exists(self, storage, node):
-        storages = self.get_storages(type=None)
+        storages = self.get_storages(None)
         # Loop through all cluster storages and get all matching storages
         validated_storagepath = [storageentry for storageentry in storages if storageentry["storage"] == storage]
         if not validated_storagepath:

--- a/plugins/modules/proxmox_storage_info.py
+++ b/plugins/modules/proxmox_storage_info.py
@@ -156,7 +156,7 @@ def main():
     if storage:
         storages = [proxmox.get_storage(storage)]
     else:
-        storages = proxmox.get_storages(storagetype=storagetype)
+        storages = proxmox.get_storages(storagetype)
     result["proxmox_storages"] = [storage.storage for storage in storages]
 
     module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY

I think this bug have been introduced during fixing Ruff lint errors. I will try to trace which PR introduce it to check if other code could be impacted.

Fixes https://github.com/ansible-collections/community.proxmox/issues/400

EDIT: here https://github.com/ansible-collections/community.proxmox/pull/256
EDIT: I have check other PR related to shadowing Python builtin, looks good