### PR TITLE
fix(pool_member): storage member

### DIFF
--- a/changelogs/fragments/411-pool-member-storage.yml
+++ b/changelogs/fragments/411-pool-member-storage.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_pool_member - fix usage of storage member (https://github.com/ansible-collections/community.proxmox/pull/411).

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -187,7 +187,7 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
     def _fail_on_missing_storage(self, storages_to_add: set[str]) -> None:
         # Validate requested storages exist before touching the API.
         if storages_to_add:
-            cluster_storages = {s["storage"] for s in self.get_storages(type=None)}
+            cluster_storages = {s["storage"] for s in self.get_storages(storagetype=None)}
             missing = storages_to_add - cluster_storages
             if missing:
                 self.module.fail_json(msg=f"Storage(s) not found in the cluster: {', '.join(sorted(missing))}")


### PR DESCRIPTION
##### SUMMARY

Currently when using `proxmox_pool_member` with storage member, the module fail because `self.get_storages` use wrong arg name.

Related to: https://github.com/ansible-collections/community.proxmox/pull/401 https://github.com/ansible-collections/community.proxmox/pull/373 https://github.com/ansible-collections/community.proxmox/pull/256

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_pool_member`
