### PR TITLE
fix(pool): pool member retrieval

### DIFF
--- a/changelogs/fragments/412-fix-pool-members.yml
+++ b/changelogs/fragments/412-fix-pool-members.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox_pool - member retrieval (https://github.com/ansible-collections/community.proxmox/pull/412).
+  - proxmox_pool_member - member retrieval (https://github.com/ansible-collections/community.proxmox/pull/412).

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -393,7 +393,7 @@ class ProxmoxAnsible:
             dict: Pool information.
         """
         try:
-            return self.proxmox_api.pools.get(poolid=poolid)
+            return self.proxmox_api.pools.get(poolid=poolid)[0]
         except Exception as e:
             self.module.fail_json(msg=f"Unable to retrieve pool {poolid} information: {e}")
 

--- a/tests/unit/plugins/modules/test_proxmox_pool_member.py
+++ b/tests/unit/plugins/modules/test_proxmox_pool_member.py
@@ -48,7 +48,7 @@ def _get_pool_mock(**kwargs):
     poolid = kwargs.get("poolid")
     for pool in SAMPLE_POOLS:
         if pool["poolid"] == poolid:
-            return pool
+            return [pool]
 
 
 def _get_vmid_mock(vm):


### PR DESCRIPTION
##### SUMMARY

Currently modules `proxmox_pool` and `proxmox_pool_member` are failing when checking pool member because `get_pool` return a list instead of an dict.

This is caused by `?poolid=poolid` which return a list but we expect only one pool returned since poolid are unique, we need to keep `?poolid=poolid` to support sub pool e.g `test/example`.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

`proxmox_pool` 
`proxmox_pool_member`