### PR TITLE
proxmox: fix LXC tags always reported as changed

### DIFF
--- a/changelogs/fragments/413-lxc-tags-diff.yml
+++ b/changelogs/fragments/413-lxc-tags-diff.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox - fix ``tags`` always being reported as changed on LXC container updates because the list value was compared against Proxmox's semicolon-delimited string form (https://github.com/ansible-collections/community.proxmox/pull/413).

--- a/changelogs/fragments/413-lxc-tags-diff.yml
+++ b/changelogs/fragments/413-lxc-tags-diff.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - proxmox - fix ``tags`` always being reported as changed on LXC container updates because the list value was compared against Proxmox's semicolon-delimited string form (https://github.com/ansible-collections/community.proxmox/pull/413).

--- a/changelogs/fragments/415-lxc-tags-diff.yml
+++ b/changelogs/fragments/415-lxc-tags-diff.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox - fix ``tags`` always being reported as changed on LXC container updates because the list value was compared against Proxmox's semicolon-delimited string form (https://github.com/ansible-collections/community.proxmox/pull/415).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -547,6 +547,9 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
 )
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 
+# Fields PVE stores as a delimited string but the module accepts as a list.
+_LIST_FIELDS = {"tags": ";"}
+
 
 def module_args():
     return dict(
@@ -970,7 +973,14 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
 
         # create diff between the current and requested config
         diff = {}
+
         for arg, value in kwargs.items():
+            if arg in _LIST_FIELDS and isinstance(value, list):
+                sep = _LIST_FIELDS[arg]
+                current = {x for x in current_config.get(arg, "").split(sep) if x}
+                if current != set(value):
+                    diff[arg] = value
+                continue
             # if the arg isn't in the current config, it needs to be added
             if arg not in current_config:
                 diff[arg] = value


### PR DESCRIPTION
## Summary
- `tags` on LXC containers is accepted as a list by the module, but Proxmox stores it as a semicolon-delimited string. The existing diff fell through to `str(value) != str(current_config[arg])`, comparing `\"['foo', 'bar']\"` against `'foo;bar'` — always different, so updates always reported `changed=True`.
- Introduces a small `_LIST_FIELDS` table mapping list-valued module args to the PVE separator and compares them as sets, so the diff is accurate and order-insensitive (matching PVE's server-side sort of tags).
- Includes a changelog fragment.

## Test plan
- [x] `nox -Re codeqa` (ruff check) — passes.
- [x] `nox -Re formatters` (ruff format) — no changes.
- [x] `nox -Re ansible-test-units-devel -- --python 3.13 tests/unit/plugins/modules/test_proxmox_lxc.py` — passes.
- [x] `nox -Re ansible-test-sanity-devel` — passes.
- [ ] Manual: update an LXC container twice with the same `tags` list and confirm the second run is `changed=False`.
- [ ] Manual: update with a reordered `tags` list and confirm `changed=False`.
- [ ] Manual: update with an added or removed tag and confirm `changed=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)