### PR TITLE
Add proxmox_qemu_api connection plugin (#416)

### DIFF
--- a/plugins/connection/proxmox_qemu_api.py
+++ b/plugins/connection/proxmox_qemu_api.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2025 Ian Williams (@aph3rson)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+---
+name: proxmox_qemu_api
+short_description: Connect to QEMU VMs via the Proxmox guest agent API
+description:
+  - Execute commands and transfer files through the Proxmox VE QEMU Guest Agent API.
+  - Does not require SSH or network connectivity to the VM.
+  - Requires the QEMU Guest Agent (C(qemu-guest-agent)) to be installed and running inside the target VM.
+  - Talks directly to the Proxmox REST API using C(proxmoxer), avoiding the overhead and limitations
+    of shelling out to C(qm guest exec) over SSH.
+  - Linux guests only. Windows guest support is not implemented.
+author:
+  - Ian Williams (@aph3rson)
+version_added: "2.0.0"
+requirements:
+  - proxmoxer >= 2.3.0
+  - requests
+options:
+  api_host:
+    description: Proxmox VE API hostname or IP address.
+    required: true
+    type: str
+    vars:
+      - name: proxmox_api_host
+    env:
+      - name: PROXMOX_HOST
+  api_port:
+    description: Proxmox VE API port.
+    default: 8006
+    type: int
+    vars:
+      - name: proxmox_api_port
+    env:
+      - name: PROXMOX_PORT
+  api_user:
+    description:
+      - Proxmox VE API user (for example V(root@pam)).
+      - Used with O(api_password) to obtain an authentication ticket.
+      - Mutually exclusive with O(api_token_id).
+    type: str
+    vars:
+      - name: proxmox_api_user
+    env:
+      - name: PROXMOX_USER
+  api_password:
+    description:
+      - Password for O(api_user).
+      - Required when O(api_user) is set.
+    type: str
+    vars:
+      - name: proxmox_api_password
+    env:
+      - name: PROXMOX_PASSWORD
+  api_token_id:
+    description:
+      - API token ID (for example V(user@pam!token_name)).
+      - Used with O(api_token_secret).
+      - Mutually exclusive with O(api_user).
+    type: str
+    vars:
+      - name: proxmox_api_token_id
+    env:
+      - name: PROXMOX_TOKEN_ID
+  api_token_secret:
+    description:
+      - API token secret UUID.
+      - Required when O(api_token_id) is set.
+    type: str
+    vars:
+      - name: proxmox_api_token_secret
+    env:
+      - name: PROXMOX_TOKEN_SECRET
+  node:
+    description: Proxmox node name where the VM resides.
+    required: true
+    type: str
+    vars:
+      - name: proxmox_node
+    env:
+      - name: PROXMOX_NODE
+  vmid:
+    description: Target QEMU VM ID.
+    required: true
+    type: int
+    vars:
+      - name: proxmox_vmid
+    env:
+      - name: PROXMOX_VMID
+  validate_certs:
+    description: Validate PVE API TLS certificates.
+    default: true
+    type: bool
+    vars:
+      - name: proxmox_validate_certs
+    env:
+      - name: PROXMOX_VERIFY_SSL
+  remote_tmp:
+    description:
+      - Temporary directory on the guest for staging chunked file transfers.
+      - Must be writable by the guest agent process (typically root).
+      - Only used when transferring files larger than 45000 bytes.
+    default: /tmp
+    type: str
+    vars:
+      - name: proxmox_remote_tmp
+  executable:
+    description: Shell executable for command execution on the guest.
+    default: /bin/sh
+    type: str
+    vars:
+      - name: ansible_executable
+  connect_timeout:
+    description:
+      - Maximum number of seconds to wait for the guest agent to become responsive.
+      - The plugin polls the agent every 5 seconds during connection.
+    default: 60
+    type: int
+    vars:
+      - name: proxmox_connect_timeout
+notes:
+  - The API user or token requires guest agent privileges on the target VM.
+    On PVE 8, this is C(VM.Monitor). On PVE 9+, C(VM.Monitor) was replaced with
+    fine-grained privileges -- C(VM.GuestAgent.Unrestricted) covers command execution,
+    C(VM.GuestAgent.FileRead) and C(VM.GuestAgent.FileWrite) cover file transfers.
+    Alternatively, C(VM.GuestAgent.Unrestricted) alone grants access to all guest agent operations.
+  - This plugin requires the QEMU Guest Agent to be installed and running inside the VM.
+    If the agent is not responsive, the connection will fail after O(connect_timeout) seconds.
+  - File transfers use the PVE guest agent file-read/file-write API, which has a per-call
+    size limit of approximately 45000 bytes. Files larger than this are automatically
+    split into chunks using C(split) on the guest and reassembled on the controller or guest.
+  - "Guest requirements: C(qemu-guest-agent) must be running. File transfers additionally
+    require C(cat), C(split), C(ls), and C(rm) (coreutils)."
+  - Works with the C(community.proxmox.proxmox) inventory plugin. Set
+    C(ansible_connection=community.proxmox.proxmox_qemu_api) on discovered hosts.
+"""
+
+EXAMPLES = r"""
+- name: Static inventory example
+  # inventory.yml
+  # all:
+  #   hosts:
+  #     my-vm:
+  #       ansible_connection: community.proxmox.proxmox_qemu_api
+  #       proxmox_vmid: 100
+  #       ansible_host: my-vm.example.com
+  #   vars:
+  #     proxmox_api_host: pve-1.example.com
+  #     proxmox_api_port: 8006
+  #     proxmox_api_token_id: automation@pve!ansible
+  #     proxmox_api_token_secret: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  #     proxmox_node: pve-1
+  hosts: my-vm
+  gather_facts: true
+  tasks:
+    - name: Install a package
+      ansible.builtin.apt:
+        name: curl
+        state: present
+
+    - name: Copy a configuration file
+      ansible.builtin.copy:
+        src: app.conf
+        dest: /etc/app/app.conf
+
+    - name: Run a command
+      ansible.builtin.command:
+        cmd: systemctl restart app
+"""
+
+import base64
+import logging
+import time
+
+from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.plugins.connection import ConnectionBase
+from ansible.utils.display import Display
+
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import HAS_PROXMOXER
+
+if HAS_PROXMOXER:
+    from proxmoxer import ProxmoxAPI
+
+display = Display()
+
+
+class _DisplayHandler(logging.Handler):
+    """Route Python logging to Ansible Display."""
+
+    _level_map = {
+        logging.DEBUG: display.vvvv,
+        logging.INFO: display.vvv,
+        logging.WARNING: display.warning,
+    }
+
+    def emit(self, record):
+        fn = self._level_map.get(record.levelno, display.warning)
+        fn(self.format(record))
+
+
+# Wire urllib3/requests logging through Display instead of stderr.
+_handler = _DisplayHandler()
+_handler.setFormatter(logging.Formatter("%(name)s: %(message)s"))
+for _name in ("urllib3", "requests", "py.warnings"):
+    _logger = logging.getLogger(_name)
+    _logger.handlers.clear()
+    _logger.addHandler(_handler)
+    _logger.propagate = False
+
+# PVE file-write content limit is 61440 bytes.
+# base64 expands 3:4, so 45000 raw bytes -> 60000 base64 chars, safely under limit.
+# TODO: Increase once Proxmox raises the QEMU guest agent file-write size limit.
+# https://forum.proxmox.com/threads/maximum-file-upload-size-for-qemu-agent-file-write.166200/
+FILE_WRITE_CHUNK = 45000
+FILE_WRITE_RETRIES = 5
+
+
+class Connection(ConnectionBase):
+    """Connection plugin that uses the Proxmox QEMU Guest Agent API."""
+
+    transport = "community.proxmox.proxmox_qemu_api"
+    has_pipelining = False
+    has_tty = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._connected = False
+        self._proxmox = None
+        logging.captureWarnings(True)
+
+    def _get_proxmox(self):
+        if self._proxmox is not None:
+            return self._proxmox
+
+        if not HAS_PROXMOXER:
+            msg = "This connection plugin requires the 'proxmoxer' library"
+            raise AnsibleError(msg) from None
+
+        host = self.get_option("api_host")
+        port = self.get_option("api_port")
+        verify_ssl = self.get_option("validate_certs")
+        token_id = self.get_option("api_token_id")
+        token_secret = self.get_option("api_token_secret")
+        user = self.get_option("api_user")
+        password = self.get_option("api_password")
+
+        if token_id and token_secret:
+            self._proxmox = ProxmoxAPI(
+                host,
+                port=port,
+                user=token_id.split("!")[0],
+                token_name=token_id.split("!")[-1],
+                token_value=token_secret,
+                verify_ssl=verify_ssl,
+            )
+        elif user and password:
+            self._proxmox = ProxmoxAPI(
+                host,
+                port=port,
+                user=user,
+                password=password,
+                verify_ssl=verify_ssl,
+            )
+        else:
+            raise AnsibleConnectionFailure(
+                "No authentication configured. Provide api_token_id + api_token_secret, or api_user + api_password."
+            )
+
+        return self._proxmox
+
+    def _agent(self):
+        proxmox = self._get_proxmox()
+        node = self.get_option("node")
+        vmid = self.get_option("vmid")
+        return proxmox.nodes(node).qemu(vmid).agent
+
+    def _connect(self):
+        if self._connected:
+            return self
+        super()._connect()
+
+        timeout = self.get_option("connect_timeout")
+        interval = 5
+        attempts = max(timeout // interval, 1)
+
+        for attempt in range(attempts):
+            try:
+                self._agent().ping.post()
+                self._connected = True
+                display.vvv(f"QEMU guest agent responsive on VM {self.get_option('vmid')}")
+                return self
+            except Exception:
+                if attempt < attempts - 1:
+                    display.vvv(
+                        f"Guest agent not ready on VM {self.get_option('vmid')}, "
+                        f"retrying in {interval}s ({attempt + 1}/{attempts})"
+                    )
+                    time.sleep(interval)
+                else:
+                    raise AnsibleConnectionFailure(
+                        f"QEMU guest agent is not responding on VM {self.get_option('vmid')} "
+                        f"after {timeout}s. Is qemu-guest-agent installed and running?"
+                    ) from None
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        super().exec_command(cmd, in_data=in_data, sudoable=sudoable)
+        self._connect()
+
+        shell = self.get_option("executable")
+        display.vvv(f"EXEC via guest agent: {cmd}")
+
+        try:
+            data = self._agent().exec.post(command=[shell, "-c", cmd])
+        except Exception as exc:
+            raise AnsibleConnectionFailure(f"Failed to execute command on VM {self.get_option('vmid')}: {exc}") from exc
+
+        pid = data["pid"]
+        status = self._poll_exec_status(pid)
+
+        rc = status.get("exitcode", -1)
+        stdout = status.get("out-data", "")
+        stderr = status.get("err-data", "")
+        return rc, stdout, stderr
+
+    def _poll_exec_status(self, pid):
+        while True:
+            time.sleep(0.5)
+            status = self._agent()("exec-status").get(pid=pid)
+            if status.get("exited"):
+                return status
+
+    def _file_write(self, guest_path, data_bytes):
+        encoded = base64.b64encode(data_bytes).decode("ascii")
+        for attempt in range(FILE_WRITE_RETRIES + 1):
+            try:
+                self._agent()("file-write").post(file=guest_path, content=encoded, encode=0)
+                return
+            except Exception:
+                if attempt < FILE_WRITE_RETRIES:
+                    time.sleep(5)
+                else:
+                    raise AnsibleConnectionFailure(
+                        f"Failed to write file {guest_path} on VM {self.get_option('vmid')} "
+                        f"after {FILE_WRITE_RETRIES + 1} attempts"
+                    ) from None
+
+    def put_file(self, in_path, out_path):
+        super().put_file(in_path, out_path)
+        self._connect()
+        display.vvv(f"PUT {in_path} -> {out_path} via guest agent")
+
+        with open(in_path, "rb") as f:
+            raw = f.read()
+
+        if len(raw) <= FILE_WRITE_CHUNK:
+            self._file_write(out_path, raw)
+            return
+
+        self._put_file_chunked(raw, out_path)
+
+    def _put_file_chunked(self, raw, out_path):
+        remote_tmp = self.get_option("remote_tmp")
+        parts = []
+        for i in range(0, len(raw), FILE_WRITE_CHUNK):
+            part_path = f"{remote_tmp}/.ansible_part_{i}"
+            parts.append(part_path)
+            self._file_write(part_path, raw[i : i + FILE_WRITE_CHUNK])
+
+        cat_cmd = "cat " + " ".join(parts) + f" > {out_path} && rm -f " + " ".join(parts)
+        rc, dummy_stdout, err = self.exec_command(cat_cmd)
+        if rc != 0:
+            raise AnsibleConnectionFailure(f"Failed to assemble chunked file on VM {self.get_option('vmid')}: {err}")
+
+    def _file_read(self, guest_path):
+        """Read a file from the guest via file-read API.
+
+        PVE encodes raw file bytes as JSON unicode escapes (\\u00XX),
+        which json.loads turns into a Python str with code points 0x00-0xFF.
+        latin-1 is the exact inverse: U+00NN -> byte 0xNN, preserving binary content.
+        """
+        result = self._agent()("file-read").get(file=guest_path)
+        content = result.get("content", "")
+        return content.encode("latin-1")
+
+    def fetch_file(self, in_path, out_path):
+        super().fetch_file(in_path, out_path)
+        self._connect()
+        display.vvv(f"FETCH {in_path} -> {out_path} via guest agent")
+
+        remote_tmp = self.get_option("remote_tmp")
+        prefix = f"{remote_tmp}/.ansible_fetch_"
+
+        # Split file into chunks on guest, read each chunk, append locally
+        split_cmd = f"split -b {FILE_WRITE_CHUNK} -- {in_path} {prefix}"
+        rc, dummy_stdout, err = self.exec_command(split_cmd)
+        if rc != 0:
+            raise AnsibleConnectionFailure(f"Failed to split file {in_path} on VM {self.get_option('vmid')}: {err}")
+
+        # List the chunk files in order
+        rc, stdout, err = self.exec_command(f"ls -1 {prefix}* 2>/dev/null")
+        if rc != 0:
+            raise AnsibleConnectionFailure(
+                f"Failed to list chunks for {in_path} on VM {self.get_option('vmid')}: {err}"
+            )
+
+        parts = stdout.strip().split("\n") if stdout.strip() else []
+
+        try:
+            with open(out_path, "wb") as f:
+                for part in parts:
+                    chunk = self._file_read(part.strip())
+                    f.write(chunk)
+        finally:
+            if parts:
+                self.exec_command(f"rm -f {prefix}*")
+
+    def close(self):
+        self._proxmox = None
+        self._connected = False
+        super().close()
+
+    def reset(self):
+        self.close()
+        self._connect()

--- a/tests/unit/plugins/connection/test_proxmox_qemu_api.py
+++ b/tests/unit/plugins/connection/test_proxmox_qemu_api.py
@@ -12,9 +12,9 @@ from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 
-proxmoxer = pytest.importorskip("proxmoxer")
+from ansible_collections.community.proxmox.plugins.connection import proxmox_qemu_api as qemu_module
 
-MODULE = "ansible_collections.community.proxmox.plugins.connection.proxmox_qemu_api"
+proxmoxer = pytest.importorskip("proxmoxer")
 
 # Test constants
 TEST_API_HOST = "pve.example.com"
@@ -70,7 +70,7 @@ def test_has_tty(connection):
     assert connection.has_tty is False
 
 
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_get_proxmox_with_token(mock_api, connection):
     """Test ProxmoxAPI initialization with token authentication."""
     connection._get_proxmox()
@@ -85,7 +85,7 @@ def test_get_proxmox_with_token(mock_api, connection):
     )
 
 
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_get_proxmox_with_password(mock_api, connection):
     """Test ProxmoxAPI initialization with password authentication."""
     connection.set_option("api_token_id", None)
@@ -115,7 +115,7 @@ def test_get_proxmox_no_auth(connection):
         connection._get_proxmox()
 
 
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_get_proxmox_caches_instance(mock_api, connection):
     """Test that ProxmoxAPI is only created once."""
     connection._get_proxmox()
@@ -124,7 +124,7 @@ def test_get_proxmox_caches_instance(mock_api, connection):
     assert mock_api.call_count == 1
 
 
-@patch(f"{MODULE}.HAS_PROXMOXER", False)
+@patch.object(qemu_module, "HAS_PROXMOXER", False)
 def test_get_proxmox_missing_library(connection):
     """Test that missing proxmoxer library raises an error."""
     connection._proxmox = None
@@ -133,7 +133,7 @@ def test_get_proxmox_missing_library(connection):
         connection._get_proxmox()
 
 
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_agent_returns_correct_path(mock_api, connection):
     """Test that _agent() builds the correct API path."""
     mock_proxmox = MagicMock()
@@ -146,8 +146,8 @@ def test_agent_returns_correct_path(mock_api, connection):
     mock_proxmox.nodes("pve-1").qemu.assert_called_once_with(100)
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_connect_success(mock_api, mock_sleep, connection):
     """Test successful connection to guest agent."""
     mock_proxmox = MagicMock()
@@ -159,8 +159,8 @@ def test_connect_success(mock_api, mock_sleep, connection):
     mock_sleep.assert_not_called()
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_connect_retries_on_failure(mock_api, mock_sleep, connection):
     """Test that connection retries when guest agent is not ready."""
     mock_proxmox = MagicMock()
@@ -176,8 +176,8 @@ def test_connect_retries_on_failure(mock_api, mock_sleep, connection):
     assert mock_sleep.call_count == 2  # noqa: PLR2004
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_connect_timeout(mock_api, mock_sleep, connection):
     """Test that connection fails after timeout."""
     mock_proxmox = MagicMock()
@@ -199,8 +199,8 @@ def test_connect_already_connected(connection):
     assert result is connection
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_exec_command_success(mock_api, mock_sleep, connection):
     """Test successful command execution."""
     mock_proxmox = MagicMock()
@@ -221,8 +221,8 @@ def test_exec_command_success(mock_api, mock_sleep, connection):
     agent.exec.post.assert_called_once_with(command=["/bin/sh", "-c", "echo hello"])
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_exec_command_nonzero_exit(mock_api, mock_sleep, connection):
     """Test command execution with non-zero exit code."""
     mock_proxmox = MagicMock()
@@ -241,7 +241,7 @@ def test_exec_command_nonzero_exit(mock_api, mock_sleep, connection):
     assert stderr == "not found\n"
 
 
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_exec_command_api_failure(mock_api, connection):
     """Test command execution when API call fails."""
     mock_proxmox = MagicMock()
@@ -257,8 +257,8 @@ def test_exec_command_api_failure(mock_api, connection):
         connection.exec_command("echo hello")
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_poll_exec_status_waits(mock_api, mock_sleep, connection):
     """Test that exec status polling waits for completion."""
     mock_proxmox = MagicMock()
@@ -278,8 +278,8 @@ def test_poll_exec_status_waits(mock_api, mock_sleep, connection):
     assert mock_sleep.call_count == 3  # noqa: PLR2004
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_file_write_success(mock_api, mock_sleep, connection):
     """Test successful file write."""
     mock_proxmox = MagicMock()
@@ -296,8 +296,8 @@ def test_file_write_success(mock_api, mock_sleep, connection):
     assert call_kwargs["encode"] == 0
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_file_write_retries(mock_api, mock_sleep, connection):
     """Test that file write retries on failure."""
     mock_proxmox = MagicMock()
@@ -312,8 +312,8 @@ def test_file_write_retries(mock_api, mock_sleep, connection):
     assert agent("file-write").post.call_count == 3  # noqa: PLR2004
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_file_write_exhausts_retries(mock_api, mock_sleep, connection):
     """Test that file write fails after exhausting retries."""
     mock_proxmox = MagicMock()
@@ -327,8 +327,8 @@ def test_file_write_exhausts_retries(mock_api, mock_sleep, connection):
         connection._file_write("/tmp/test", b"hello")
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_put_file_small(mock_api, mock_sleep, connection):
     """Test putting a small file (under chunk size)."""
     mock_proxmox = MagicMock()
@@ -343,8 +343,8 @@ def test_put_file_small(mock_api, mock_sleep, connection):
     agent("file-write").post.assert_called_once()
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_put_file_chunked(mock_api, mock_sleep, connection):
     """Test putting a large file that requires chunking."""
     mock_proxmox = MagicMock()
@@ -366,8 +366,8 @@ def test_put_file_chunked(mock_api, mock_sleep, connection):
     agent.exec.post.assert_called_once()
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_put_file_chunked_uses_remote_tmp(mock_api, mock_sleep, connection):
     """Test that chunked file transfer uses the configured remote_tmp."""
     mock_proxmox = MagicMock()
@@ -390,8 +390,8 @@ def test_put_file_chunked_uses_remote_tmp(mock_api, mock_sleep, connection):
     assert "/var/tmp/.ansible_part_" in cmd
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_put_file_chunked_assemble_failure(mock_api, mock_sleep, connection):
     """Test that chunked file transfer fails if assembly fails."""
     mock_proxmox = MagicMock()
@@ -410,8 +410,8 @@ def test_put_file_chunked_assemble_failure(mock_api, mock_sleep, connection):
         connection.put_file("/local/path", "/remote/path")
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_fetch_file_small(mock_api, mock_sleep, connection):
     """Test fetching a small file (single chunk)."""
     mock_proxmox = MagicMock()
@@ -436,8 +436,8 @@ def test_fetch_file_small(mock_api, mock_sleep, connection):
     m().write.assert_called_once_with(b"hello world")
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_fetch_file_chunked(mock_api, mock_sleep, connection):
     """Test fetching a large file that requires multiple chunks."""
     mock_proxmox = MagicMock()
@@ -473,8 +473,8 @@ def test_fetch_file_chunked(mock_api, mock_sleep, connection):
     assert calls[2][0][0] == chunk_c.encode("latin-1")
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_fetch_file_binary(mock_api, mock_sleep, connection):
     """Test fetching a binary file preserves bytes via latin-1 encoding."""
     mock_proxmox = MagicMock()
@@ -500,8 +500,8 @@ def test_fetch_file_binary(mock_api, mock_sleep, connection):
     assert written == bytes(range(256))
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_fetch_file_split_failure(mock_api, mock_sleep, connection):
     """Test that fetch fails if split command fails."""
     mock_proxmox = MagicMock()
@@ -526,8 +526,8 @@ def test_close(connection):
     assert connection._proxmox is None
 
 
-@patch(f"{MODULE}.time.sleep")
-@patch(f"{MODULE}.ProxmoxAPI")
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
 def test_reset(mock_api, mock_sleep, connection):
     """Test connection reset closes and reconnects."""
     mock_proxmox = MagicMock()

--- a/tests/unit/plugins/connection/test_proxmox_qemu_api.py
+++ b/tests/unit/plugins/connection/test_proxmox_qemu_api.py
@@ -1,0 +1,541 @@
+# Copyright (c) 2025 Ian (@aph3rson)
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import connection_loader
+
+proxmoxer = pytest.importorskip("proxmoxer")
+
+MODULE = "ansible_collections.community.proxmox.plugins.connection.proxmox_qemu_api"
+
+# Test constants
+TEST_API_HOST = "pve.example.com"
+TEST_API_PORT = 8006
+TEST_NODE = "pve-1"
+TEST_VMID = 100
+TEST_CONNECT_TIMEOUT = 60
+
+
+@pytest.fixture
+def connection():
+    """Create a connection instance with minimal required options."""
+    play_context = PlayContext()
+    in_stream = StringIO()
+    conn = connection_loader.get("community.proxmox.proxmox_qemu_api", play_context, in_stream)
+    conn.set_option("api_host", TEST_API_HOST)
+    conn.set_option("api_port", TEST_API_PORT)
+    conn.set_option("api_token_id", "user@pam!token")
+    conn.set_option("api_token_secret", "secret-uuid")
+    conn.set_option("node", TEST_NODE)
+    conn.set_option("vmid", TEST_VMID)
+    conn.set_option("validate_certs", True)
+    conn.set_option("remote_tmp", "/tmp")
+    conn.set_option("executable", "/bin/sh")
+    conn.set_option("connect_timeout", TEST_CONNECT_TIMEOUT)
+    return conn
+
+
+def test_connection_options(connection):
+    """Test that connection options are properly set."""
+    assert connection.get_option("api_host") == "pve.example.com"
+    assert connection.get_option("api_port") == TEST_API_PORT
+    assert connection.get_option("node") == "pve-1"
+    assert connection.get_option("vmid") == TEST_VMID
+    assert connection.get_option("validate_certs") is True
+    assert connection.get_option("remote_tmp") == "/tmp"
+    assert connection.get_option("executable") == "/bin/sh"
+    assert connection.get_option("connect_timeout") == TEST_CONNECT_TIMEOUT
+
+
+def test_transport_name(connection):
+    """Test that the transport name is correct."""
+    assert connection.transport == "community.proxmox.proxmox_qemu_api"
+
+
+def test_has_pipelining(connection):
+    """Test that pipelining is disabled."""
+    assert connection.has_pipelining is False
+
+
+def test_has_tty(connection):
+    """Test that TTY is disabled."""
+    assert connection.has_tty is False
+
+
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_get_proxmox_with_token(mock_api, connection):
+    """Test ProxmoxAPI initialization with token authentication."""
+    connection._get_proxmox()
+
+    mock_api.assert_called_once_with(
+        "pve.example.com",
+        port=TEST_API_PORT,
+        user="user@pam",
+        token_name="token",
+        token_value="secret-uuid",
+        verify_ssl=True,
+    )
+
+
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_get_proxmox_with_password(mock_api, connection):
+    """Test ProxmoxAPI initialization with password authentication."""
+    connection.set_option("api_token_id", None)
+    connection.set_option("api_token_secret", None)
+    connection.set_option("api_user", "root@pam")
+    connection.set_option("api_password", "password123")
+
+    connection._get_proxmox()
+
+    mock_api.assert_called_once_with(
+        "pve.example.com",
+        port=TEST_API_PORT,
+        user="root@pam",
+        password="password123",
+        verify_ssl=True,
+    )
+
+
+def test_get_proxmox_no_auth(connection):
+    """Test that missing authentication raises an error."""
+    connection.set_option("api_token_id", None)
+    connection.set_option("api_token_secret", None)
+    connection.set_option("api_user", None)
+    connection.set_option("api_password", None)
+
+    with pytest.raises(AnsibleConnectionFailure, match="No authentication configured"):
+        connection._get_proxmox()
+
+
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_get_proxmox_caches_instance(mock_api, connection):
+    """Test that ProxmoxAPI is only created once."""
+    connection._get_proxmox()
+    connection._get_proxmox()
+
+    assert mock_api.call_count == 1
+
+
+@patch(f"{MODULE}.HAS_PROXMOXER", False)
+def test_get_proxmox_missing_library(connection):
+    """Test that missing proxmoxer library raises an error."""
+    connection._proxmox = None
+
+    with pytest.raises(AnsibleError, match="requires the 'proxmoxer' library"):
+        connection._get_proxmox()
+
+
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_agent_returns_correct_path(mock_api, connection):
+    """Test that _agent() builds the correct API path."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    connection._get_proxmox()
+    connection._agent()
+
+    mock_proxmox.nodes.assert_called_once_with("pve-1")
+    mock_proxmox.nodes("pve-1").qemu.assert_called_once_with(100)
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_connect_success(mock_api, mock_sleep, connection):
+    """Test successful connection to guest agent."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    connection._connect()
+
+    assert connection._connected is True
+    mock_sleep.assert_not_called()
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_connect_retries_on_failure(mock_api, mock_sleep, connection):
+    """Test that connection retries when guest agent is not ready."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.ping.post.side_effect = [Exception("not ready"), Exception("not ready"), None]
+
+    connection.set_option("connect_timeout", 15)
+    connection._connect()
+
+    assert connection._connected is True
+    assert mock_sleep.call_count == 2  # noqa: PLR2004
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_connect_timeout(mock_api, mock_sleep, connection):
+    """Test that connection fails after timeout."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.ping.post.side_effect = Exception("not ready")
+
+    connection.set_option("connect_timeout", 10)
+
+    with pytest.raises(AnsibleConnectionFailure, match="QEMU guest agent is not responding"):
+        connection._connect()
+
+
+def test_connect_already_connected(connection):
+    """Test that _connect() is a no-op when already connected."""
+    connection._connected = True
+    result = connection._connect()
+    assert result is connection
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_exec_command_success(mock_api, mock_sleep, connection):
+    """Test successful command execution."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 42}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 0, "out-data": "hello\n", "err-data": ""}
+
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    rc, stdout, stderr = connection.exec_command("echo hello")
+
+    assert rc == 0
+    assert stdout == "hello\n"
+    assert stderr == ""
+    agent.exec.post.assert_called_once_with(command=["/bin/sh", "-c", "echo hello"])
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_exec_command_nonzero_exit(mock_api, mock_sleep, connection):
+    """Test command execution with non-zero exit code."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 42}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 1, "out-data": "", "err-data": "not found\n"}
+
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    rc, stdout, stderr = connection.exec_command("false")
+
+    assert rc == 1
+    assert stderr == "not found\n"
+
+
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_exec_command_api_failure(mock_api, connection):
+    """Test command execution when API call fails."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.side_effect = Exception("API error")
+
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    with pytest.raises(AnsibleConnectionFailure, match="Failed to execute command"):
+        connection.exec_command("echo hello")
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_poll_exec_status_waits(mock_api, mock_sleep, connection):
+    """Test that exec status polling waits for completion."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("exec-status").get.side_effect = [
+        {"exited": 0},
+        {"exited": 0},
+        {"exited": 1, "exitcode": 0, "out-data": "done"},
+    ]
+
+    status = connection._poll_exec_status(42)
+
+    assert status["out-data"] == "done"
+    assert mock_sleep.call_count == 3  # noqa: PLR2004
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_file_write_success(mock_api, mock_sleep, connection):
+    """Test successful file write."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+
+    connection._file_write("/tmp/test", b"hello")
+
+    agent("file-write").post.assert_called_once()
+    call_kwargs = agent("file-write").post.call_args[1]
+    assert call_kwargs["file"] == "/tmp/test"
+    assert call_kwargs["encode"] == 0
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_file_write_retries(mock_api, mock_sleep, connection):
+    """Test that file write retries on failure."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-write").post.side_effect = [Exception("busy"), Exception("busy"), None]
+
+    connection._file_write("/tmp/test", b"hello")
+
+    assert agent("file-write").post.call_count == 3  # noqa: PLR2004
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_file_write_exhausts_retries(mock_api, mock_sleep, connection):
+    """Test that file write fails after exhausting retries."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-write").post.side_effect = Exception("busy")
+
+    with pytest.raises(AnsibleConnectionFailure, match="Failed to write file"):
+        connection._file_write("/tmp/test", b"hello")
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_put_file_small(mock_api, mock_sleep, connection):
+    """Test putting a small file (under chunk size)."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    with patch("builtins.open", mock_open(read_data=b"small file")):
+        connection.put_file("/local/path", "/remote/path")
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-write").post.assert_called_once()
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_put_file_chunked(mock_api, mock_sleep, connection):
+    """Test putting a large file that requires chunking."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 1}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 0, "out-data": "", "err-data": ""}
+
+    large_data = b"x" * 100000
+    with patch("builtins.open", mock_open(read_data=large_data)):
+        connection.put_file("/local/path", "/remote/path")
+
+    # Should have written 3 chunks (45000 + 45000 + 10000)
+    assert agent("file-write").post.call_count == 3  # noqa: PLR2004
+    # Should have run cat to assemble
+    agent.exec.post.assert_called_once()
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_put_file_chunked_uses_remote_tmp(mock_api, mock_sleep, connection):
+    """Test that chunked file transfer uses the configured remote_tmp."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+    connection.set_option("remote_tmp", "/var/tmp")
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 1}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 0, "out-data": "", "err-data": ""}
+
+    large_data = b"x" * 50000
+    with patch("builtins.open", mock_open(read_data=large_data)):
+        connection.put_file("/local/path", "/remote/path")
+
+    # Check that the cat command references /var/tmp
+    exec_call = agent.exec.post.call_args
+    cmd = exec_call[1]["command"][2]
+    assert "/var/tmp/.ansible_part_" in cmd
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_put_file_chunked_assemble_failure(mock_api, mock_sleep, connection):
+    """Test that chunked file transfer fails if assembly fails."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 1}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 1, "out-data": "", "err-data": "disk full"}
+
+    large_data = b"x" * 50000
+    with pytest.raises(AnsibleConnectionFailure, match="Failed to assemble chunked file"), patch(
+        "builtins.open", mock_open(read_data=large_data)
+    ):
+        connection.put_file("/local/path", "/remote/path")
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_fetch_file_small(mock_api, mock_sleep, connection):
+    """Test fetching a small file (single chunk)."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-read").get.return_value = {"content": "hello world"}
+
+    with patch.object(connection, "exec_command") as mock_exec:
+        mock_exec.side_effect = [
+            (0, "", ""),  # split
+            (0, "/tmp/.ansible_fetch_aa\n", ""),  # ls
+            (0, "", ""),  # rm
+        ]
+        m = mock_open()
+        with patch("builtins.open", m):
+            connection.fetch_file("/remote/path", "/local/path")
+
+    m.assert_called_with("/local/path", "wb")
+    m().write.assert_called_once_with(b"hello world")
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_fetch_file_chunked(mock_api, mock_sleep, connection):
+    """Test fetching a large file that requires multiple chunks."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    chunk_a = "a" * 45000
+    chunk_b = "b" * 45000
+    chunk_c = "c" * 10000
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-read").get.side_effect = [
+        {"content": chunk_a},
+        {"content": chunk_b},
+        {"content": chunk_c},
+    ]
+
+    with patch.object(connection, "exec_command") as mock_exec:
+        mock_exec.side_effect = [
+            (0, "", ""),  # split
+            (0, "/tmp/.ansible_fetch_aa\n/tmp/.ansible_fetch_ab\n/tmp/.ansible_fetch_ac\n", ""),  # ls
+            (0, "", ""),  # rm
+        ]
+        m = mock_open()
+        with patch("builtins.open", m):
+            connection.fetch_file("/remote/path", "/local/path")
+
+    assert agent("file-read").get.call_count == 3  # noqa: PLR2004
+    calls = m().write.call_args_list
+    assert len(calls) == 3  # noqa: PLR2004
+    assert calls[0][0][0] == chunk_a.encode("latin-1")
+    assert calls[1][0][0] == chunk_b.encode("latin-1")
+    assert calls[2][0][0] == chunk_c.encode("latin-1")
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_fetch_file_binary(mock_api, mock_sleep, connection):
+    """Test fetching a binary file preserves bytes via latin-1 encoding."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    binary_as_str = "".join(chr(i) for i in range(256))
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent("file-read").get.return_value = {"content": binary_as_str}
+
+    with patch.object(connection, "exec_command") as mock_exec:
+        mock_exec.side_effect = [
+            (0, "", ""),  # split
+            (0, "/tmp/.ansible_fetch_aa\n", ""),  # ls
+            (0, "", ""),  # rm
+        ]
+        m = mock_open()
+        with patch("builtins.open", m):
+            connection.fetch_file("/remote/path", "/local/path")
+
+    written = m().write.call_args[0][0]
+    assert written == bytes(range(256))
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_fetch_file_split_failure(mock_api, mock_sleep, connection):
+    """Test that fetch fails if split command fails."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    with patch.object(connection, "exec_command") as mock_exec:
+        mock_exec.return_value = (1, "", "No such file")
+        with pytest.raises(AnsibleConnectionFailure, match="Failed to split file"):
+            connection.fetch_file("/remote/path", "/local/path")
+
+
+def test_close(connection):
+    """Test connection close."""
+    connection._connected = True
+    connection._proxmox = MagicMock()
+
+    connection.close()
+
+    assert connection._connected is False
+    assert connection._proxmox is None
+
+
+@patch(f"{MODULE}.time.sleep")
+@patch(f"{MODULE}.ProxmoxAPI")
+def test_reset(mock_api, mock_sleep, connection):
+    """Test connection reset closes and reconnects."""
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    connection.reset()
+
+    # After reset, should be connected again
+    assert connection._connected is True


### PR DESCRIPTION
##### SUMMARY

New connection plugin for QEMU VMs via the Proxmox guest agent API. Uses proxmoxer to talk directly to the PVE REST API, avoiding the overhead and size limitations of SSH + qm guest exec.

Includes 31 unit tests.

Fixes #416

##### ISSUE TYPE

- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME

`community.proxmox.proxmox_qemu_api` (connection plugin)

##### ADDITIONAL INFORMATION

See linked issue for example usage.