### PR TITLE
fix(acme_account): set no_log on sensitive value eab_kid

### DIFF
--- a/changelogs/fragments/418-acme-account-eab_kid-no-log.yml
+++ b/changelogs/fragments/418-acme-account-eab_kid-no-log.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_acme_account - set ``no_log`` on sensitive value ``eab_kid`` (https://github.com/ansible-collections/community.proxmox/pull/418).

--- a/plugins/modules/proxmox_acme_account.py
+++ b/plugins/modules/proxmox_acme_account.py
@@ -157,7 +157,7 @@ def module_args():
         contact=dict(type="str"),
         directory=dict(type="str"),
         eab_hmac_key=dict(type="str", no_log=True),
-        eab_kid=dict(type="str"),
+        eab_kid=dict(type="str", no_log=True),
         tos=dict(type="str", aliases=["tos_url"]),
     )
 


### PR DESCRIPTION
##### SUMMARY

The field `eab_kid` defines an external account binding which is a sensitive value and should be marked as `no_log`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_acme_account`