### PR TITLE
(proxmox,proxmox_kvm) Add destroy_unreferenced_disks parameter

### DIFF
--- a/changelogs/fragments/422-destroy-unref-disks-option.yml
+++ b/changelogs/fragments/422-destroy-unref-disks-option.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - proxmox - add ``destroy_unreferenced_disks`` parameter (https://github.com/ansible-collections/community.proxmox/pull/422).
+  - proxmox_kvm - add ``destroy_unreferenced_disks`` parameter (https://github.com/ansible-collections/community.proxmox/pull/422).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -250,6 +250,13 @@ options:
       - Used with O(state=absent).
     type: bool
     default: false
+  destroy_unreferenced_disks:
+    description:
+      - Remove unreferenced disks that belong to the container.
+      - Volumes referenced in the config (e.g. via rootfs or mpX parameters) will always be removed.
+      - Used with O(state=absent).
+    type: bool
+    default: false
   state:
     description:
       - Indicate desired state of the instance.
@@ -531,6 +538,14 @@ EXAMPLES = r"""
     state: absent
 
 - name: >-
+    Remove container, deleting all volumes that use the container's ID, regardless
+    of whether they are mentioned in the container config or not
+  community.proxmox.proxmox:
+    vmid: 100
+    state: absent
+    destroy_unreferenced_disks: true
+
+- name: >-
     Create a new container automatically selecting the next available vmid
     using a non-root API token
   community.proxmox.proxmox:
@@ -662,6 +677,7 @@ def module_args():
         update=dict(type="bool", default=True),
         force=dict(type="bool", default=False),
         purge=dict(type="bool", default=False),
+        destroy_unreferenced_disks=dict(type="bool", default=False),
         state=dict(
             default="present",
             choices=[
@@ -743,6 +759,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 node=self.params.get("node"),
                 timeout=self.params.get("timeout"),
                 purge=self.params.get("purge"),
+                destroy_unreferenced_disks=self.params.get("destroy_unreferenced_disks"),
                 force=self.params.get("force"),
             )
         elif state == "started":
@@ -843,7 +860,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             force=force,
         )
 
-    def lxc_absent(self, vmid, hostname, node, timeout, purge, force):  # noqa: PLR0913
+    def lxc_absent(self, vmid, hostname, node, timeout, purge, destroy_unreferenced_disks, force):  # noqa: PLR0913
         try:
             lxc = self.get_lxc_resource(vmid, hostname)
         except LookupError:
@@ -869,7 +886,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
                 msg=f"VM {identifier} is mounted. Stop it with force option before deletion.",
             )
 
-        self.remove_lxc_instance(vmid, node, timeout, purge, force)
+        self.remove_lxc_instance(vmid, node, timeout, purge, destroy_unreferenced_disks, force)
         self.module.exit_json(changed=True, vmid=vmid, msg=f"VM {identifier} removed.")
 
     def lxc_started(self, vmid, hostname, node, timeout):
@@ -1254,10 +1271,13 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             timeout_msg="Reached timeout while waiting for VM to be unmounted.",
         )
 
-    def remove_lxc_instance(self, vmid, node, timeout, purge, force):
+    def remove_lxc_instance(self, vmid, node, timeout, purge, destroy_unreferenced_disks, force):
         delete_params = {}
         if purge:
             delete_params["purge"] = 1
+
+        if destroy_unreferenced_disks:
+            delete_params["destroy-unreferenced-disks"] = 1
 
         if force:
             delete_params["force"] = 1

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -1271,7 +1271,7 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             timeout_msg="Reached timeout while waiting for VM to be unmounted.",
         )
 
-    def remove_lxc_instance(self, vmid, node, timeout, purge, destroy_unreferenced_disks, force):
+    def remove_lxc_instance(self, vmid, node, timeout, purge, destroy_unreferenced_disks, force):  # noqa: PLR0913
         delete_params = {}
         if purge:
             delete_params["purge"] = 1

--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -122,6 +122,13 @@ options:
       - Specify the description for the VM. Only used on the configuration web interface.
       - This is saved as comment inside the configuration file.
     type: str
+  destroy_unreferenced_disks:
+    description:
+      - Remove unreferenced disks that belong to the virtual machine.
+      - Volumes referenced in the config will always be removed.
+      - Used with O(state=absent).
+    type: bool
+    default: false
   digest:
     description:
       - Specify if to prevent changes if current configuration file has different SHA1 digest.
@@ -786,6 +793,15 @@ EXAMPLES = r"""
     node: sabrewulf
     state: absent
 
+- name: >-
+    Remove VM, deleting all volumes that use the VM's ID, regardless
+    of whether they are mentioned in the config or not
+  community.proxmox.proxmox_kvm:
+    name: spynal
+    node: sabrewulf
+    state: absent
+    destroy_unreferenced_disks: true
+
 - name: Get VM current state
   community.proxmox.proxmox_kvm:
     name: spynal
@@ -901,6 +917,7 @@ def module_args():
         cpuunits=dict(type="int"),
         delete=dict(type="str"),
         description=dict(type="str"),
+        destroy_unreferenced_disks=dict(type="bool", default=False),
         digest=dict(type="str"),
         efidisk0=dict(
             type="dict",
@@ -1639,6 +1656,8 @@ def main():  # noqa: PLR0912, PLR0915
             delete_params = {}
             if module.params["purge"]:
                 delete_params["purge"] = 1
+            if module.params["destroy_unreferenced_disks"]:
+                delete_params["destroy-unreferenced-disks"] = 1
             taskid = proxmox_node.qemu.delete(vmid, **delete_params)
             if not proxmox.wait_for_task(vm["node"], taskid):
                 module.fail_json(


### PR DESCRIPTION
##### SUMMARY
The Proxmox API supports removing unreferenced disks (i.e. disks that contain the VMID in their name but are not referenced in the container/VM config via the destroy-unreferenced-disks parameter. This PR adds this option as a new module parameter "destroy_unreferenced_disks" to both proxmox and proxmox_kvm modules.

The module parameter defaults to 'False' and the modules themselves send '1' via the API if it is set to True.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
proxmox
proxmox_kvm

##### ADDITIONAL INFORMATION
Since Proxmox usually takes good care of making sure there are no unreferenced volumes, the easiest way to test this is to
- create a VM/Container with an additional volume besides the root volume attached
- stop the VM/Container and manually remove the reference to that volume from the config file