### PR TITLE
Feat/add cluster firewall security group

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -27,6 +27,7 @@ action_groups:
     - proxmox_ceph_pool
     - proxmox_cluster
     - proxmox_cluster_firewall
+    - proxmox_cluster_firewall_security_group
     - proxmox_cluster_ha_resources
     - proxmox_cluster_ha_rules
     - proxmox_cluster_ha_rules_info

--- a/plugins/modules/proxmox_cluster_firewall.py
+++ b/plugins/modules/proxmox_cluster_firewall.py
@@ -88,6 +88,9 @@ seealso:
   - name: Proxmox VE cluster-wide configuration
     description: Complete reference of Proxmox VE Firewall
     link: https://pve.proxmox.com/pve-docs/chapter-pve-firewall.html#pve_firewall_cluster_wide_setup
+  - module: community.proxmox.proxmox_node_firewall
+  - module: community.proxmox.proxmox_firewall
+  - module: community.proxmox.proxmox_cluster_firewall_security_group
 
 extends_documentation_fragment:
   - community.proxmox.proxmox.actiongroup_proxmox

--- a/plugins/modules/proxmox_cluster_firewall_security_group.py
+++ b/plugins/modules/proxmox_cluster_firewall_security_group.py
@@ -267,13 +267,13 @@ def _build_create_rule_payload(desired_rule, position, group_name):
         "enable": ansible_to_proxmox_bool(desired_rule.get("enabled", True)),
     }
     for ansible_key, api_key in _OPTIONAL_RULE_TO_API.items():
-        if desired_rule.get(ansible_key) is not None:
+        if desired_rule.get(ansible_key):
             payload[api_key] = desired_rule[ansible_key]
-    if group_name is not None:
+    if group_name:
         payload["group"] = group_name
-    if position is not None:
+    if position:
         payload["pos"] = position
-    return {k: v for k, v in payload.items() if v is not None or k == "enable"}
+    return {k: v for k, v in payload.items() if v or k == "enable"}
 
 
 def _build_update_rule_payload(desired_rule, current_rule):

--- a/plugins/modules/proxmox_cluster_firewall_security_group.py
+++ b/plugins/modules/proxmox_cluster_firewall_security_group.py
@@ -1,0 +1,660 @@
+#!/usr/bin/python
+
+# Copyright (c) 2026, Clément Cruau (@PendaGTP) <38917281+PendaGTP@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+DOCUMENTATION = r"""
+module: proxmox_cluster_firewall_security_group
+short_description: Cluster firewall security group management for Proxmox VE
+version_added: "2.0.0"
+author:
+  - Clément Cruau (@PendaGTP)
+description:
+  - Manage cluster-level firewall security groups in Proxmox VE.
+  - Security groups hold ordered firewall rules that can be attached to guest rules.
+  - If O(rules) is omitted when O(state=present), the module only creates the group and/or
+    updates its comment; existing rules are not read or modified.
+  - If O(rules) is set (including an empty list), the module synchronizes the full ordered
+    ruleset, mapping list index 0 to position 0, etc.
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+options:
+  state:
+    description:
+      - The desired state of the security group.
+    type: str
+    choices:
+      - present
+      - absent
+    default: present
+  name:
+    description:
+      - Security group name.
+    type: str
+    required: true
+  comment:
+    description:
+      - Security group comment.
+    type: str
+  rules:
+    description:
+      - Full ordered list of firewall rules for the group, with index C(0) as position C(0), etc.
+      - Omitted to manage only the group and comment, leaving current rules unchanged.
+      - V([]) to remove all rules.
+      - Optional rule fields (O(rules[].comment), O(rules[].dest), etc.) that are omitted in a rule
+        entry are preserved from the existing rule on updates.
+    type: list
+    elements: dict
+    suboptions:
+      action:
+        description:
+          - Rule action (V(ACCEPT), V(DROP), V(REJECT), or a security group name if
+            O(rules[].type) is V(group).
+        type: str
+        required: true
+      type:
+        description:
+          - Rule direction or special type.
+        type: str
+        required: true
+        choices:
+          - in
+          - out
+          - forward
+          - group
+      comment:
+        description:
+          - Rule comment.
+        type: str
+      dest:
+        description:
+          - Match packet destination address.
+            This can refer to a single IP address, an IP set ('+ipsetname') or an IP alias definition.
+            You can also specify an address range like C(20.34.101.207-201.3.9.99),
+            or a list of IP addresses and networks (entries are separated by comma).
+            Please do not mix IPv4 and IPv6 addresses inside such lists.
+        type: str
+      dport:
+        description:
+          - Match TCP/UDP destination port.
+            You can use service names or simple numbers V(0-65535), as defined in C(/etc/services).
+            Port ranges can be specified with '\d+:\d+', for example V(80:85), and you can use comma separated list to match several ports or ranges.
+        type: str
+      enabled:
+        description:
+          - Whether the rule is active.
+        type: bool
+        default: true
+      iface:
+        description:
+          - Network interface name.
+        type: str
+      log:
+        description:
+          - Log level for matching packets.
+        type: str
+        choices:
+          - emerg
+          - alert
+          - crit
+          - err
+          - warning
+          - notice
+          - info
+          - debug
+          - nolog
+      macro:
+        description:
+          - Built-in firewall macro name.
+          - Use predefined standard macro from https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_firewall_macro_definitions
+        type: str
+      proto:
+        description:
+          - Match IP protocol (name or number per C(/etc/protocols)).
+        type: str
+      source:
+        description:
+          - Match packet source address.
+            This can refer to a single IP address, an IP set ('+ipsetname') or an IP alias definition.
+            You can also specify an address range like C(20.34.101.207-201.3.9.99),
+            or a list of IP addresses and networks (entries are separated by comma).
+            Please do not mix IPv4 and IPv6 addresses inside such lists.
+        type: str
+      sport:
+        description:
+          - Match TCP/UDP source port.
+            You can use service names or simple numbers V(0-65535), as defined in C(/etc/services).
+            Port ranges can be specified with '\d+:\d+', for example V(80:85), and you can use comma separated list to match several ports or ranges.
+        type: str
+      icmp_type:
+        description:
+          - ICMP type (when O(rules[].proto) is C(icmp) or C(icmpv6)/C(ipv6-icmp)).
+        type: str
+
+seealso:
+  - name: Proxmox VE security group reference
+    description: Security group reference for Proxmox VE Firewall
+    link: https://pve.proxmox.com/pve-docs/chapter-pve-firewall.html#pve_firewall_security_groups
+  - module: community.proxmox.proxmox_cluster_firewall
+  - module: community.proxmox.proxmox_node_firewall
+  - module: community.proxmox.proxmox_firewall
+
+extends_documentation_fragment:
+  - community.proxmox.proxmox.actiongroup_proxmox
+  - community.proxmox.proxmox.documentation
+  - community.proxmox.proxmox.attributes
+"""
+
+EXAMPLES = r"""
+- name: Webserver security group
+  community.proxmox.proxmox_cluster_firewall_security_group:
+    name: webserver
+    comment: Managed by Ansible
+    rules:
+      - type: in
+        action: ACCEPT
+        comment: Allow HTTP
+        dest: 192.168.1.100
+        dport: "80"
+        proto: tcp
+        log: info
+      - type: in
+        action: ACCEPT
+        comment: Allow HTTPS
+        dest: 192.168.1.100
+        dport: "443"
+        proto: tcp
+        log: info
+"""
+
+RETURN = r"""
+name:
+  description: The security group name.
+  returned: on success
+  type: str
+  sample: webserver
+comment:
+  description: The security group comment.
+  returned: on success
+  type: str
+  sample: Managed by Ansible
+rules:
+  description: The security group rules.
+  returned: on success, only if O(state=present) and O(rules) is set
+  type: list
+  elements: dict
+  sample: []
+msg:
+  description: A short message on what the module did.
+  returned: always
+  type: str
+  sample: "Security group web updated"
+"""
+
+from ansible.module_utils.common.text.converters import to_native
+
+from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
+    ProxmoxAnsible,
+    ansible_to_proxmox_bool,
+    create_proxmox_module,
+    is_not_found_error,
+    proxmox_to_ansible_bool,
+)
+
+_COMPARABLE_RULE_KEYS = {
+    "action",
+    "type",
+    "comment",
+    "dest",
+    "dport",
+    "enable",
+    "iface",
+    "log",
+    "macro",
+    "proto",
+    "source",
+    "sport",
+    "icmp-type",
+}
+
+_COMPARE_OPTIONAL_KEYS = tuple(k for k in _COMPARABLE_RULE_KEYS if k not in ("action", "type", "enable"))
+
+
+def _api_rule_to_ansible(r):
+    """Map one API rule dict to Ansible-style keys (for return)."""
+    if not r:
+        return r
+    out = {}
+    for k, v in r.items():
+        if k == "enable":
+            out["enabled"] = proxmox_to_ansible_bool(v)
+        elif k == "icmp-type":
+            out["icmp_type"] = v
+        else:
+            out[k] = v
+    return out
+
+
+def _normalize_for_return(r):
+    """Normalize a user-supplied Ansible rule dict for consistent return in check mode."""
+    out = dict(r)
+    out.setdefault("enabled", True)
+    return out
+
+
+_OPTIONAL_RULE_TO_API = {
+    "comment": "comment",
+    "dest": "dest",
+    "dport": "dport",
+    "iface": "iface",
+    "log": "log",
+    "macro": "macro",
+    "proto": "proto",
+    "source": "source",
+    "sport": "sport",
+    "icmp_type": "icmp-type",
+}
+
+
+def _build_create_rule_payload(desired_rule, position, group_name):
+    payload = {
+        "action": desired_rule["action"],
+        "type": desired_rule["type"],
+        "enable": ansible_to_proxmox_bool(desired_rule.get("enabled", True)),
+    }
+    for ansible_key, api_key in _OPTIONAL_RULE_TO_API.items():
+        if desired_rule.get(ansible_key) is not None:
+            payload[api_key] = desired_rule[ansible_key]
+    if group_name is not None:
+        payload["group"] = group_name
+    if position is not None:
+        payload["pos"] = position
+    return {k: v for k, v in payload.items() if v is not None or k == "enable"}
+
+
+def _build_update_rule_payload(desired_rule, current_rule):
+    """Build API body for updating an existing rule, seeding from current state."""
+    payload = {}
+    if current_rule:
+        for k in _COMPARABLE_RULE_KEYS:
+            if current_rule.get(k) is not None:
+                payload[k] = current_rule[k]
+    payload["action"] = desired_rule["action"]
+    payload["type"] = desired_rule["type"]
+    payload["enable"] = ansible_to_proxmox_bool(desired_rule.get("enabled", True))
+    for ansible_key, api_key in _OPTIONAL_RULE_TO_API.items():
+        if desired_rule.get(ansible_key) is not None:
+            payload[api_key] = desired_rule[ansible_key]
+    return {k: v for k, v in payload.items() if v is not None or k == "enable"}
+
+
+def _normalize_compare_optional(key, value):
+    if value is None or value == "":
+        return None
+    if key in ("dport", "sport") and isinstance(value, int):
+        return str(value)
+    return value
+
+
+def _normalize_for_compare(api_rule):
+    if not api_rule:
+        return None
+    action = api_rule.get("action")
+    rtype = api_rule.get("type")
+    out = {
+        "action": action,
+        "type": rtype,
+        "enabled": proxmox_to_ansible_bool(api_rule.get("enable")),
+    }
+    for key in _COMPARE_OPTIONAL_KEYS:
+        value = api_rule.get(key)
+        normalized = _normalize_compare_optional(key, value)
+        if normalized is None:
+            continue
+        out_key = "icmp_type" if key == "icmp-type" else key
+        out[out_key] = normalized
+    return out
+
+
+def _rules_content_equal(a_api, b_api):
+    return _normalize_for_compare(a_api) == _normalize_for_compare(b_api)
+
+
+def _put_rule_payload(merged):
+    return {k: v for k, v in merged.items() if k not in ("pos", "ipversion", "digest", "group")}
+
+
+def _sort_rules(rules):
+    return sorted(rules, key=lambda x: x["pos"])
+
+
+def module_args():
+    return dict(
+        state=dict(choices=["present", "absent"], default="present"),
+        name=dict(type="str", required=True),
+        comment=dict(type="str", default=None),
+        rules=dict(
+            type="list",
+            elements="dict",
+            default=None,
+            options=dict(
+                action=dict(type="str", required=True),
+                type=dict(type="str", required=True, choices=["in", "out", "forward", "group"]),
+                comment=dict(type="str"),
+                dest=dict(type="str"),
+                dport=dict(type="str"),
+                enabled=dict(type="bool", default=True),
+                iface=dict(type="str"),
+                log=dict(
+                    type="str",
+                    choices=["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "nolog"],
+                ),
+                macro=dict(type="str"),
+                proto=dict(type="str"),
+                source=dict(type="str"),
+                sport=dict(type="str"),
+                icmp_type=dict(type="str"),
+            ),
+        ),
+    )
+
+
+def module_options():
+    return dict()
+
+
+class ProxmoxClusterFirewallSecurityGroupAnsible(ProxmoxAnsible):
+    def __init__(self, module):
+        super().__init__(module)
+        self.params = module.params
+
+    def run(self):
+        state = self.params["state"]
+        name = self.params["name"]
+
+        if state == "present":
+            self._ensure_present(name)
+        else:
+            self._ensure_absent(name)
+
+    def _ensure_present(self, name):
+        existing = self._fetch_group(name)
+
+        if existing is None:
+            if self.module.check_mode:
+                rules_param = self.params.get("rules")
+                self.module.exit_json(
+                    changed=True,
+                    name=name,
+                    msg=f"Security group {name} would be created",
+                    comment=self.params.get("comment"),
+                    rules=[_normalize_for_return(r) for r in rules_param] if rules_param is not None else None,
+                )
+
+            result = self._create(name, self.params.get("rules") or [])
+            self.module.exit_json(**result)
+
+        result = self._reconcile(name, existing)
+        self.module.exit_json(**result)
+
+    def _ensure_absent(self, name):
+        existing = self._fetch_group(name)
+
+        if existing is None:
+            self.module.exit_json(
+                changed=False,
+                name=name,
+                msg=f"Firewall security group {name} does not exist",
+            )
+
+        if self.module.check_mode:
+            self.module.exit_json(
+                changed=True,
+                name=name,
+                msg=f"Firewall security group {name} would be deleted",
+            )
+
+        result = self._delete(name)
+        self.module.exit_json(**result)
+
+    def _create(self, name, rules):
+        self._create_group(name)
+        self._create_rules(name, rules)
+        rules_param = self.params.get("rules")
+        fetched_rules = self._fetch_rules(name) if rules_param is not None else None
+        result = self._build_present_result(name, self.params.get("comment"), fetched_rules)
+        return {
+            "changed": True,
+            "msg": f"Firewall security group {name} successfully created",
+            **result,
+        }
+
+    def _delete(self, name):
+        self._delete_rules(name)
+        self._delete_group(name)
+        return {
+            "changed": True,
+            "name": name,
+            "msg": f"Firewall security group {name} successfully deleted",
+        }
+
+    def _reconcile(self, name, existing):
+        comment = self.params.get("comment")
+        rules_param = self.params.get("rules")
+
+        existing_comment = existing.get("comment") or ""
+        need_comment = comment is not None and (existing_comment != (comment or ""))
+        need_rules = rules_param is not None and self._rules_would_change(rules_param, name)
+        will_change = need_comment or need_rules
+
+        if self.module.check_mode:
+            if not will_change:
+                res = {
+                    "changed": False,
+                    "name": name,
+                    "msg": f"Firewall security group {name} is already in desired state",
+                }
+                res["comment"] = existing.get("comment")
+                if rules_param is not None:
+                    res["rules"] = [_api_rule_to_ansible(x) for x in self._fetch_rules(name)]
+                return res
+            res = {
+                "changed": True,
+                "name": name,
+                "msg": f"Firewall security group {name} would be updated",
+                "comment": comment if comment is not None else existing.get("comment"),
+            }
+            if rules_param is not None:
+                res["rules"] = [_normalize_for_return(r) for r in rules_param]
+            return res
+
+        changed = False
+        if need_comment:
+            self._update_group_comment(name, comment, existing)
+            changed = True
+        if need_rules:
+            self._reconcile_rules(name, rules_param)
+            changed = True
+
+        actual_comment = comment if need_comment else existing.get("comment")
+        fetched_rules = self._fetch_rules(name) if rules_param is not None else None
+        result = self._build_present_result(name, actual_comment, fetched_rules)
+        msg = (
+            f"Firewall security group {name} successfully updated"
+            if changed
+            else f"Firewall security group {name} is already in desired state"
+        )
+        return {
+            "changed": changed,
+            "name": name,
+            "msg": msg,
+            **result,
+        }
+
+    def _build_present_result(self, name, comment, rules):
+        out = {"name": name, "comment": comment}
+        if rules is not None:
+            out["rules"] = [_api_rule_to_ansible(x) for x in rules]
+        return out
+
+    def _create_group(self, name):
+        try:
+            self.proxmox_api.cluster().firewall().groups().post(**self._build_create_group_params())
+        except Exception as e:
+            self.module.fail_json(msg=f"Failed to create firewall security group {name}: {to_native(e)}")
+
+    def _build_create_group_params(self):
+        p = self.params
+        payload = {"group": p["name"]}
+        if p.get("comment"):
+            payload["comment"] = p["comment"]
+        return payload
+
+    def _delete_group(self, name):
+        try:
+            self.proxmox_api.cluster().firewall().groups(name).delete()
+        except Exception as e:
+            self.module.fail_json(msg=f"Failed to delete firewall security group {name}: {to_native(e)}")
+
+    def _update_group_comment(self, name, comment, existing):
+        try:
+            self.proxmox_api.cluster().firewall().groups().post(
+                **self._build_update_group_comment_params(name, comment, existing)
+            )
+        except Exception as e:
+            self.module.fail_json(msg=f"Failed to update firewall security group {name}: {to_native(e)}")
+
+    def _build_update_group_comment_params(self, name, comment, existing):
+        payload = {"group": name, "rename": name, "comment": comment}
+        if existing.get("digest"):
+            payload["digest"] = existing["digest"]
+        return payload
+
+    def _fetch_group(self, name):
+        try:
+            groups = self.proxmox_api.cluster().firewall().groups().get()
+            return next((group for group in groups if group["group"] == name), None)
+        except Exception as e:
+            if is_not_found_error(e):
+                return None
+            self.module.fail_json(msg=f"Failed to read firewall security groups: {to_native(e)}")
+
+    def _rules_would_change(self, desired, group_name):
+        current = self._fetch_rules(group_name)
+        if len(desired) != len(current):
+            return True
+        for i, d in enumerate(desired):
+            want = _build_update_rule_payload(d, current[i])
+            if not _rules_content_equal(want, current[i]):
+                return True
+        return False
+
+    def _create_rules(self, name, desired):
+        for i, rule in enumerate(desired):
+            payload = _build_create_rule_payload(rule, i, name)
+            try:
+                self.proxmox_api.cluster().firewall().groups(name).post(**payload)
+            except Exception as e:
+                self.module.fail_json(msg=f"Failed to create firewall rule in security group {name}: {to_native(e)}")
+
+    def _delete_rules(self, name):
+        rules = self._fetch_rules(name)
+        while rules:
+            rule = max(rules, key=lambda r: r["pos"])
+            digest = rule.get("digest")
+            try:
+                del_kw = {}
+                if digest:
+                    del_kw["digest"] = digest
+                self.proxmox_api.cluster().firewall().groups(name)(rule["pos"]).delete(**del_kw)
+            except Exception as e:
+                self.module.fail_json(
+                    msg=f"Failed to delete firewall rule in security group {name} at position {rule['pos']}: {to_native(e)}"
+                )
+            rules = self._fetch_rules(name)
+
+    def _fetch_rules(self, name):
+        try:
+            rules = self.proxmox_api.cluster().firewall().groups(name).get()
+            return _sort_rules(rules)
+        except Exception as e:
+            self.module.fail_json(msg=f"Failed to read firewall rules for security group {name}: {to_native(e)}")
+
+    def _reconcile_rules(self, name, desired):
+        rules = self._prune_excess_rules(name, desired)
+        self._update_rules_in_prefix(name, desired, rules)
+        self._create_missing_trailing_rules(name, desired, rules)
+
+    def _prune_excess_rules(self, name, desired):
+        rules = self._fetch_rules(name)
+
+        while len(rules) > len(desired):
+            position = max(rule["pos"] for rule in rules)
+            rule_at_pos = next(r for r in rules if r["pos"] == position)
+            digest = rule_at_pos.get("digest")
+            try:
+                del_kw = {"pos": position}
+                if digest:
+                    del_kw["digest"] = digest
+                self.proxmox_api.cluster().firewall().groups(name)(position).delete(**del_kw)
+            except Exception as e:
+                self.module.fail_json(
+                    msg=f"Failed to delete firewall rule in security group {name} at position {position}: {to_native(e)}"
+                )
+            rules = self._fetch_rules(name)
+
+        return rules
+
+    def _update_rules_in_prefix(self, name, desired, rules):
+        for i in range(min(len(desired), len(rules))):
+            want = _build_update_rule_payload(desired[i], rules[i])
+            if _rules_content_equal(want, rules[i]):
+                continue
+            try:
+                self.proxmox_api.cluster().firewall().groups(name)(i).put(**_put_rule_payload(want))
+            except Exception as e:
+                self.module.fail_json(
+                    msg=f"Failed to update firewall rule in security group {name} at position {i}: {to_native(e)}"
+                )
+
+    def _create_missing_trailing_rules(self, name, desired, rules):
+        while len(rules) < len(desired):
+            i = len(rules)
+            body = _build_create_rule_payload(desired[i], i, name)
+            try:
+                self.proxmox_api.cluster().firewall().groups(name).post(**body)
+            except Exception as e:
+                self.module.fail_json(
+                    msg=f"Failed to create firewall rule in security group {name} at position {i}: {to_native(e)}"
+                )
+            self._move_rule_to_correct_pos(name, body)
+            rules = self._fetch_rules(name)
+
+    def _move_rule_to_correct_pos(self, name, rule):
+        """If Proxmox inserts new rules at pos 0, move them to the intended position."""
+        position = rule.get("pos")
+        if position is None or position == 0:
+            return
+        try:
+            self.proxmox_api.cluster().firewall().groups(name)(0).put(moveto=(position + 1))
+        except Exception as e:
+            self.module.fail_json(
+                msg=f"Failed to move firewall rule in security group {name} at position {position}: {to_native(e)}"
+            )
+
+
+def main():
+    module = create_proxmox_module(module_args(), **module_options())
+    proxmox = ProxmoxClusterFirewallSecurityGroupAnsible(module)
+    try:
+        proxmox.run()
+    except Exception as e:
+        module.fail_json(msg=f"An error occurred: {to_native(e)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/proxmox_cluster_firewall_security_group.py
+++ b/plugins/modules/proxmox_cluster_firewall_security_group.py
@@ -325,7 +325,12 @@ def _rules_content_equal(a_api, b_api):
 
 
 def _put_rule_payload(merged):
-    return {k: v for k, v in merged.items() if k not in ("pos", "ipversion", "digest", "group")}
+    return {k: v for k, v in merged.items() if k not in ("pos", "ipversion", "group")}
+
+
+def _is_digest_conflict_error(exc):
+    text = to_native(exc).lower()
+    return "detected modified configuration" in text and "file changed by other user" in text
 
 
 def _sort_rules(rules):
@@ -611,15 +616,24 @@ class ProxmoxClusterFirewallSecurityGroupAnsible(ProxmoxAnsible):
 
     def _update_rules_in_prefix(self, name, desired, rules):
         for i in range(min(len(desired), len(rules))):
-            want = _build_update_rule_payload(desired[i], rules[i])
-            if _rules_content_equal(want, rules[i]):
-                continue
-            try:
-                self.proxmox_api.cluster().firewall().groups(name)(i).put(**_put_rule_payload(want))
-            except Exception as e:
-                self.module.fail_json(
-                    msg=f"Failed to update firewall rule in security group {name} at position {i}: {to_native(e)}"
-                )
+            retries_left = 1
+            while True:
+                try:
+                    current_rule = self.proxmox_api.cluster().firewall().groups(name)(i).get()
+                    want = _build_update_rule_payload(desired[i], current_rule)
+                    if current_rule.get("digest"):
+                        want["digest"] = current_rule["digest"]
+                    if _rules_content_equal(want, current_rule):
+                        break
+                    self.proxmox_api.cluster().firewall().groups(name)(i).put(**_put_rule_payload(want))
+                    break
+                except Exception as e:
+                    if retries_left > 0 and _is_digest_conflict_error(e):
+                        retries_left -= 1
+                        continue
+                    self.module.fail_json(
+                        msg=f"Failed to update firewall rule in security group {name} at position {i}: {to_native(e)}"
+                    )
 
     def _create_missing_trailing_rules(self, name, desired, rules):
         while len(rules) < len(desired):

--- a/plugins/modules/proxmox_cluster_firewall_security_group.py
+++ b/plugins/modules/proxmox_cluster_firewall_security_group.py
@@ -640,6 +640,15 @@ class ProxmoxClusterFirewallSecurityGroupAnsible(ProxmoxAnsible):
         if position is None or position == 0:
             return
         try:
+            rule_at0 = self.proxmox_api.cluster().firewall().groups(name)(0).get()
+            for param, value in rule_at0.items():
+                if param in rule and param != "pos" and value != rule.get(param):
+                    self.module.warn(
+                        f"Skipping rule position workaround for security group {name}: "
+                        f"rule at pos 0 does not match the rule just created. "
+                        f"Verify rule is at correct position."
+                    )
+                    return
             self.proxmox_api.cluster().firewall().groups(name)(0).put(moveto=(position + 1))
         except Exception as e:
             self.module.fail_json(

--- a/plugins/modules/proxmox_cluster_firewall_security_group.py
+++ b/plugins/modules/proxmox_cluster_firewall_security_group.py
@@ -7,7 +7,7 @@
 DOCUMENTATION = r"""
 module: proxmox_cluster_firewall_security_group
 short_description: Cluster firewall security group management for Proxmox VE
-version_added: "2.0.0"
+version_added: "2.1.0"
 author:
   - Clément Cruau (@PendaGTP)
 description:

--- a/tests/integration/targets/proxmox_cluster_firewall_security_group/aliases
+++ b/tests/integration/targets/proxmox_cluster_firewall_security_group/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported
+proxmox_cluster_firewall_security_group

--- a/tests/integration/targets/proxmox_cluster_firewall_security_group/defaults/main.yml
+++ b/tests/integration/targets/proxmox_cluster_firewall_security_group/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (c) 2026, Clément Cruau (@PendaGTP) <38917281+PendaGTP@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+sg_name: ansible-test-sg

--- a/tests/integration/targets/proxmox_cluster_firewall_security_group/meta/main.yml
+++ b/tests/integration/targets/proxmox_cluster_firewall_security_group/meta/main.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+dependencies:
+  - setup_proxmox_auth

--- a/tests/integration/targets/proxmox_cluster_firewall_security_group/tasks/main.yml
+++ b/tests/integration/targets/proxmox_cluster_firewall_security_group/tasks/main.yml
@@ -1,0 +1,810 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Copyright (c) 2026, Clément Cruau (@PendaGTP) <38917281+PendaGTP@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Cluster firewall security group management
+  tags: ["proxmox_cluster_firewall_security_group"]
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    # -------------------------------------------------------------------------
+    # Ensure clean state before starting
+    # -------------------------------------------------------------------------
+
+    - name: Delete security group if it exists from a previous run
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      ignore_errors: true
+
+    # -------------------------------------------------------------------------
+    # Create with rules in a single call
+    # -------------------------------------------------------------------------
+
+    - name: Create security group with rules in one shot (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Created with rules"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.comment == "Created with rules"
+          - result.rules | length == 1
+          - result.rules[0].action == "ACCEPT"
+          - result.rules[0].dport == "80"
+          - result.rules[0].enabled == true
+
+    - name: Create security group with rules in one shot
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Created with rules"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.comment == "Created with rules"
+          - result.rules | length == 1
+          - result.rules[0].type == "in"
+          - result.rules[0].action == "ACCEPT"
+          - result.rules[0].dport == "80"
+          - result.rules[0].enabled == true
+
+    - name: Delete security group to reset state
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+
+    # -------------------------------------------------------------------------
+    # Create — check mode
+    # -------------------------------------------------------------------------
+
+    - name: Create security group (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Managed by Ansible"
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result is success
+          - result.name == sg_name
+          - result.comment == "Managed by Ansible"
+
+    - name: Verify group was not actually created (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - "'does not exist' in result.msg"
+
+    # -------------------------------------------------------------------------
+    # Create — actual
+    # -------------------------------------------------------------------------
+
+    - name: Create security group
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Managed by Ansible"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result is success
+          - result.name == sg_name
+          - result.comment == "Managed by Ansible"
+          - "'rules' not in result"
+
+    - name: Create security group again (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Managed by Ansible"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.name == sg_name
+          - result.comment == "Managed by Ansible"
+
+    # -------------------------------------------------------------------------
+    # Update comment
+    # -------------------------------------------------------------------------
+
+    - name: Update comment (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Updated comment"
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.comment == "Updated comment"
+
+    - name: Update comment
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Updated comment"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.comment == "Updated comment"
+
+    - name: Update comment (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Updated comment"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # -------------------------------------------------------------------------
+    # Rules — create
+    # -------------------------------------------------------------------------
+
+    - name: Add rules (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTPS
+            dest: 192.168.1.100
+            dport: "443"
+            proto: tcp
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 2
+          - result.rules[0].action == "ACCEPT"
+          - result.rules[0].dport == "80"
+          - result.rules[1].dport == "443"
+
+    - name: Add rules
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTPS
+            dest: 192.168.1.100
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 2
+          - result.rules[0].type == "in"
+          - result.rules[0].action == "ACCEPT"
+          - result.rules[0].dport == "80"
+          - result.rules[0].enabled == true
+          - result.rules[1].dport == "443"
+
+    - name: Add rules (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTPS
+            dest: 192.168.1.100
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules | length == 2
+
+    # -------------------------------------------------------------------------
+    # Rules — omitting rules param leaves rules unchanged
+    # -------------------------------------------------------------------------
+
+    - name: Update comment without touching rules
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        comment: "Restored comment"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.comment == "Restored comment"
+          - "'rules' not in result"
+
+    # -------------------------------------------------------------------------
+    # Rules — update in place
+    # -------------------------------------------------------------------------
+
+    - name: Update rule at position 0 in place
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            comment: Block HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTPS
+            dest: 192.168.1.100
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules[0].action == "DROP"
+          - result.rules[0].comment == "Block HTTP"
+          - result.rules[1].action == "ACCEPT"
+
+    - name: Update rule at position 0 (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            comment: Block HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            comment: Allow HTTPS
+            dest: 192.168.1.100
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # -------------------------------------------------------------------------
+    # Rules — prune (reduce count)
+    # -------------------------------------------------------------------------
+
+    - name: Prune to one rule (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            comment: Block HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Prune to one rule
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            comment: Block HTTP
+            dest: 192.168.1.100
+            dport: "80"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 1
+          - result.rules[0].dport == "80"
+
+    # -------------------------------------------------------------------------
+    # Rules — clear all rules with empty list
+    # -------------------------------------------------------------------------
+
+    - name: Clear all rules (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules: []
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Clear all rules
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules: []
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 0
+
+    - name: Clear all rules (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules: []
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules | length == 0
+
+    # -------------------------------------------------------------------------
+    # Rules — add a trailing rule (group already has 0 rules)
+    # -------------------------------------------------------------------------
+
+    - name: Add one rule to an empty group
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 1
+          - result.rules[0].dport == "22"
+
+    # -------------------------------------------------------------------------
+    # Rules — check mode for in-place rule content change (same count, new action)
+    # -------------------------------------------------------------------------
+
+    - name: Update rule content in place (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            dport: "22"
+            proto: tcp
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules[0].action == "DROP"
+
+    - name: Verify rule unchanged after check mode
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules | length == 1
+          - result.rules[0].action == "ACCEPT"
+
+    # -------------------------------------------------------------------------
+    # Rules — append to grow list (1 → 3), including a type: out rule
+    # -------------------------------------------------------------------------
+
+    - name: Grow rule list from 1 to 3 (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 3
+          - result.rules[2].type == "out"
+
+    - name: Grow rule list from 1 to 3
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 3
+          - result.rules[2].type == "out"
+
+    - name: Grow rule list from 1 to 3 (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules | length == 3
+
+    # -------------------------------------------------------------------------
+    # Rules — disabled rule (enabled: false)
+    # -------------------------------------------------------------------------
+
+    - name: "Disable a rule (enabled: false)"
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+            enabled: false
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules[0].enabled == false
+          - result.rules[1].enabled == true
+
+    - name: "Disable a rule (idempotent)"
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            dport: "22"
+            proto: tcp
+            enabled: false
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules[0].enabled == false
+
+    # -------------------------------------------------------------------------
+    # Rules — optional fields (source, log)
+    # -------------------------------------------------------------------------
+
+    - name: Set rules with optional fields (source, log)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            source: 10.0.0.0/8
+            dport: "22"
+            proto: tcp
+            log: info
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules[0].source == "10.0.0.0/8"
+          - result.rules[0].log == "info"
+
+    - name: Set rules with optional fields (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            source: 10.0.0.0/8
+            dport: "22"
+            proto: tcp
+            log: info
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # -------------------------------------------------------------------------
+    # Rules — preserve omitted optional fields on in-place update
+    # -------------------------------------------------------------------------
+
+    - name: Update rule while omitting existing optional fields (source, log)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            dport: "22"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules[0].action == "DROP"
+          - result.rules[0].source == "10.0.0.0/8"
+          - result.rules[0].log == "info"
+
+    - name: Omitted optional fields remain preserved (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: DROP
+            dport: "22"
+            proto: tcp
+          - type: in
+            action: ACCEPT
+            dport: "80"
+            proto: tcp
+          - type: out
+            action: ACCEPT
+            dport: "443"
+            proto: tcp
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules[0].source == "10.0.0.0/8"
+          - result.rules[0].log == "info"
+
+    # -------------------------------------------------------------------------
+    # Rules — icmp_type API mapping and roundtrip
+    # -------------------------------------------------------------------------
+
+    - name: Clear rules before ICMP scenario
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules: []
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 0
+
+    - name: Set ICMP rule with icmp_type
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            proto: icmp
+            icmp_type: "echo-request"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result.rules | length == 1
+          - result.rules[0].proto == "icmp"
+          - result.rules[0].icmp_type == "echo-request"
+
+    - name: Set ICMP rule with icmp_type (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        rules:
+          - type: in
+            action: ACCEPT
+            proto: icmp
+            icmp_type: "echo-request"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - result.rules | length == 1
+          - result.rules[0].icmp_type == "echo-request"
+
+    # -------------------------------------------------------------------------
+    # Delete — check mode
+    # -------------------------------------------------------------------------
+
+    - name: Delete security group (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result is success
+
+    - name: Verify group still exists after check mode delete
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    # -------------------------------------------------------------------------
+    # Delete — actual
+    # -------------------------------------------------------------------------
+
+    - name: Delete security group
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+          - result is success
+          - result.name == sg_name
+
+    - name: Delete non-existent security group (idempotent)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - "'does not exist' in result.msg"
+
+    # -------------------------------------------------------------------------
+    # State=absent check mode when group does not exist
+    # -------------------------------------------------------------------------
+
+    - name: Delete non-existent security group (check mode)
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+          - "'does not exist' in result.msg"
+
+  rescue:
+    - name: Delete test security group if it was created
+      community.proxmox.proxmox_cluster_firewall_security_group:
+        name: "{{ sg_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/unit/plugins/modules/test_proxmox_cluster_firewall_security_group.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_firewall_security_group.py
@@ -307,8 +307,8 @@ class TestNormalizeForReturn:
 
 
 class TestPutRulePayload:
-    def test_strips_pos_ipversion_digest_group(self):
-        """PUT payload must omit immutable/unsupported fields rejected by Proxmox API."""
+    def test_strips_pos_ipversion_group_and_keeps_digest(self):
+        """PUT payload must keep digest lock while omitting unsupported positional metadata."""
         merged = {
             "action": "ACCEPT",
             "type": "in",
@@ -322,8 +322,8 @@ class TestPutRulePayload:
         result = _put_rule_payload(merged)
         assert "pos" not in result
         assert "ipversion" not in result
-        assert "digest" not in result
         assert "group" not in result
+        assert result["digest"] == "abc123"
         assert result["action"] == "ACCEPT"
         assert result["dport"] == "80"
 
@@ -385,6 +385,7 @@ class TestProxmoxClusterFirewallSecurityGroupModule(ModuleTestCase):
         self.groups_base = Mock()
         self.groups_named = Mock()
         self.rule_at_pos = Mock()
+        self.rule_at_pos.get.return_value = SAMPLE_RULE_0
         self.groups_named.return_value = self.rule_at_pos
 
         fw.groups.side_effect = lambda *args: self.groups_named if args else self.groups_base
@@ -604,6 +605,7 @@ class TestProxmoxClusterFirewallSecurityGroupModule(ModuleTestCase):
         """Rule content drift in shared prefix should trigger PUT, not recreate."""
         self.groups_base.get.return_value = [SAMPLE_GROUP]
         updated_rule = {**SAMPLE_RULE_0, "dport": "8080"}
+        self.rule_at_pos.get.return_value = SAMPLE_RULE_0
         self.groups_named.get.side_effect = [
             [SAMPLE_RULE_0],  # _rules_would_change (content differs)
             [SAMPLE_RULE_0],  # _prune_excess_rules
@@ -614,6 +616,7 @@ class TestProxmoxClusterFirewallSecurityGroupModule(ModuleTestCase):
 
         assert result["changed"] is True
         self.rule_at_pos.put.assert_called_once()
+        assert self.rule_at_pos.put.call_args[1].get("digest") == SAMPLE_RULE_0["digest"]
         self.rule_at_pos.delete.assert_not_called()
         assert result["rules"][0]["dport"] == "8080"
 
@@ -788,12 +791,32 @@ class TestProxmoxClusterFirewallSecurityGroupModule(ModuleTestCase):
             [SAMPLE_RULE_0],  # _rules_would_change (content differs)
             [SAMPLE_RULE_0],  # _prune_excess_rules
         ]
+        self.rule_at_pos.get.return_value = SAMPLE_RULE_0
         self.rule_at_pos.put.side_effect = Exception("conflict")
 
         result = self._run_module(build_module_args(rules=[{**DESIRED_RULE_0, "dport": "8080"}]))
 
         assert result.get("failed") is True
         assert "Failed to update firewall rule" in result["msg"]
+
+    def test_update_rule_in_prefix_retries_once_on_digest_conflict(self):
+        """Digest mismatches should trigger one refetch+retry before failing."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # _rules_would_change (content differs)
+            [SAMPLE_RULE_0],  # _prune_excess_rules
+            [{**SAMPLE_RULE_0, "dport": "8080"}],  # final fetch
+        ]
+        self.rule_at_pos.get.side_effect = [SAMPLE_RULE_0, SAMPLE_RULE_0]
+        self.rule_at_pos.put.side_effect = [
+            Exception("detected modified configuration - file changed by other user? Try again."),
+            None,
+        ]
+
+        result = self._run_module(build_module_args(rules=[{**DESIRED_RULE_0, "dport": "8080"}]))
+
+        assert result["changed"] is True
+        assert self.rule_at_pos.put.call_count == 2  # noqa: PLR2004
 
     # -- missing behavioural scenarios ----------------------------------------
 

--- a/tests/unit/plugins/modules/test_proxmox_cluster_firewall_security_group.py
+++ b/tests/unit/plugins/modules/test_proxmox_cluster_firewall_security_group.py
@@ -1,0 +1,822 @@
+#
+# Copyright (c) 2026, Clément Cruau (@PendaGTP) <38917281+PendaGTP@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+proxmoxer = pytest.importorskip("proxmoxer")
+
+from ansible.module_utils import basic
+from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import (
+    ModuleTestCase,
+    set_module_args,
+)
+
+from ansible_collections.community.proxmox.plugins.modules import proxmox_cluster_firewall_security_group
+from ansible_collections.community.proxmox.plugins.modules.proxmox_cluster_firewall_security_group import (
+    _api_rule_to_ansible,
+    _build_create_rule_payload,
+    _build_update_rule_payload,
+    _normalize_for_compare,
+    _normalize_for_return,
+    _put_rule_payload,
+    _rules_content_equal,
+    _sort_rules,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+GROUP_NAME = "webserver"
+
+SAMPLE_GROUP = {
+    "group": GROUP_NAME,
+    "comment": "Managed by Ansible",
+    "digest": "abc123",
+}
+
+SAMPLE_RULE_0 = {
+    "pos": 0,
+    "type": "in",
+    "action": "ACCEPT",
+    "enable": 1,
+    "comment": "Allow HTTP",
+    "dest": "192.168.1.100",
+    "dport": "80",
+    "proto": "tcp",
+    "digest": "rule-digest-0",
+}
+
+SAMPLE_RULE_1 = {
+    "pos": 1,
+    "type": "in",
+    "action": "ACCEPT",
+    "enable": 1,
+    "comment": "Allow HTTPS",
+    "dest": "192.168.1.100",
+    "dport": "443",
+    "proto": "tcp",
+    "digest": "rule-digest-1",
+}
+
+# Ansible-side representation of SAMPLE_RULE_0 / SAMPLE_RULE_1
+DESIRED_RULE_0 = {
+    "action": "ACCEPT",
+    "type": "in",
+    "enabled": True,
+    "comment": "Allow HTTP",
+    "dest": "192.168.1.100",
+    "dport": "80",
+    "proto": "tcp",
+}
+
+DESIRED_RULE_1 = {
+    "action": "ACCEPT",
+    "type": "in",
+    "enabled": True,
+    "comment": "Allow HTTPS",
+    "dest": "192.168.1.100",
+    "dport": "443",
+    "proto": "tcp",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise SystemExit(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise SystemExit(kwargs)
+
+
+def build_module_args(state="present", **overrides):
+    args = {
+        "api_host": "host",
+        "api_user": "user",
+        "api_password": "password",
+        "name": GROUP_NAME,
+        "state": state,
+    }
+    args.update(overrides)
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — standalone helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestApiRuleToAnsible:
+    def test_renames_enable_to_enabled_bool(self):
+        """Ensure API `enable` is converted to Ansible `enabled` for stable return values."""
+        result = _api_rule_to_ansible({"action": "ACCEPT", "type": "in", "enable": 1})
+        assert result["enabled"] is True
+        assert "enable" not in result
+
+    def test_disabled_rule(self):
+        """Guard disabled rule conversion so state comparisons handle disabled rules correctly."""
+        result = _api_rule_to_ansible({"action": "ACCEPT", "type": "in", "enable": 0})
+        assert result["enabled"] is False
+
+    def test_renames_icmp_type_hyphen_to_underscore(self):
+        """Verify API `icmp-type` maps to `icmp_type` expected by module args/results."""
+        result = _api_rule_to_ansible({"action": "ACCEPT", "type": "in", "enable": 1, "icmp-type": "echo-request"})
+        assert result["icmp_type"] == "echo-request"
+        assert "icmp-type" not in result
+
+    def test_other_fields_pass_through(self):
+        """Prevent accidental dropping of unrelated rule fields during API->Ansible conversion."""
+        result = _api_rule_to_ansible(
+            {"action": "ACCEPT", "type": "in", "enable": 1, "pos": 2, "dport": "80", "digest": "abc"}
+        )
+        assert result["pos"] == 2  # noqa: PLR2004
+        assert result["dport"] == "80"
+        assert result["digest"] == "abc"
+
+    def test_empty_dict_returns_empty(self):
+        """Keep empty payload handling predictable and avoid injecting synthetic defaults."""
+        assert _api_rule_to_ansible({}) == {}
+
+    def test_falsy_input_returns_as_is(self):
+        """Preserve `None` passthrough to avoid masking missing-rule conditions upstream."""
+        assert _api_rule_to_ansible(None) is None
+
+
+class TestNormalizeForCompare:
+    def test_required_fields(self):
+        """Confirm normalization always compares the required identity fields and enabled flag."""
+        result = _normalize_for_compare({"action": "ACCEPT", "type": "in", "enable": 1})
+        assert result == {"action": "ACCEPT", "type": "in", "enabled": True}
+
+    def test_empty_string_optional_excluded(self):
+        """Ignore empty/None optional values so harmless API noise does not trigger drift."""
+        result = _normalize_for_compare({"action": "DROP", "type": "out", "enable": 1, "comment": "", "dport": None})
+        assert "comment" not in result
+        assert "dport" not in result
+
+    def test_non_empty_optional_included(self):
+        """Ensure meaningful optional fields participate in rule drift detection."""
+        result = _normalize_for_compare({"action": "ACCEPT", "type": "in", "enable": 1, "dport": "80", "proto": "tcp"})
+        assert result["dport"] == "80"
+        assert result["proto"] == "tcp"
+
+    def test_dport_int_normalized_to_str(self):
+        """Normalize integer ports to strings to prevent false-positive updates."""
+        result = _normalize_for_compare({"action": "ACCEPT", "type": "in", "enable": 1, "dport": 80})
+        assert result["dport"] == "80"
+
+    def test_icmp_type_key_renamed(self):
+        """Use canonical `icmp_type` key during compare so API/user key styles match."""
+        result = _normalize_for_compare({"action": "ACCEPT", "type": "in", "enable": 1, "icmp-type": "echo-request"})
+        assert result["icmp_type"] == "echo-request"
+        assert "icmp-type" not in result
+
+    def test_none_input_returns_none(self):
+        """Allow callers to treat missing rules distinctly from normalized rule dicts."""
+        assert _normalize_for_compare(None) is None
+
+
+class TestRulesContentEqual:
+    def test_identical_rules_equal(self):
+        """Baseline equality check proving compare function is stable for unchanged rules."""
+        assert _rules_content_equal(SAMPLE_RULE_0, SAMPLE_RULE_0) is True
+
+    def test_different_action_not_equal(self):
+        """Catch action changes so ACCEPT/DROP drift is never ignored."""
+        assert _rules_content_equal(SAMPLE_RULE_0, {**SAMPLE_RULE_0, "action": "DROP"}) is False
+
+    def test_different_dport_not_equal(self):
+        """Catch port changes so traffic policy updates are applied."""
+        assert _rules_content_equal(SAMPLE_RULE_0, {**SAMPLE_RULE_0, "dport": "443"}) is False
+
+    def test_different_enable_not_equal(self):
+        """Catch enabled/disabled flips so rule activation drift is reconciled."""
+        assert _rules_content_equal({**SAMPLE_RULE_0, "enable": 1}, {**SAMPLE_RULE_0, "enable": 0}) is False
+
+    def test_digest_and_pos_ignored(self):
+        """Confirm metadata-only differences do not force unnecessary updates."""
+        a = {**SAMPLE_RULE_0, "digest": "aaa", "pos": 0}
+        b = {**SAMPLE_RULE_0, "digest": "bbb", "pos": 5}
+        assert _rules_content_equal(a, b) is True
+
+
+class TestBuildCreateRulePayload:
+    def test_required_and_positional_fields(self):
+        """Ensure create payload includes required rule fields plus ordering/group placement."""
+        payload = _build_create_rule_payload({"action": "ACCEPT", "type": "in", "enabled": True}, 2, GROUP_NAME)
+        assert payload["action"] == "ACCEPT"
+        assert payload["type"] == "in"
+        assert payload["enable"] == 1
+        assert payload["pos"] == 2  # noqa: PLR2004
+        assert payload["group"] == GROUP_NAME
+
+    def test_optional_fields_included_when_set(self):
+        """Verify user-provided optional attributes are sent to API on create."""
+        rule = {"action": "ACCEPT", "type": "in", "dport": "80", "proto": "tcp", "comment": "test"}
+        payload = _build_create_rule_payload(rule, 0, GROUP_NAME)
+        assert payload["dport"] == "80"
+        assert payload["proto"] == "tcp"
+        assert payload["comment"] == "test"
+
+    def test_optional_fields_excluded_when_none(self):
+        """Avoid sending explicit null optional fields that can clobber API defaults."""
+        rule = {"action": "ACCEPT", "type": "in", "dport": None, "comment": None}
+        payload = _build_create_rule_payload(rule, 0, GROUP_NAME)
+        assert "dport" not in payload
+        assert "comment" not in payload
+
+    def test_enabled_false_maps_to_zero(self):
+        """Proxmox expects numeric booleans; this prevents wrong enabled state on create."""
+        payload = _build_create_rule_payload({"action": "DROP", "type": "in", "enabled": False}, 0, GROUP_NAME)
+        assert payload["enable"] == 0
+
+    def test_icmp_type_key_converted(self):
+        """Validate Ansible `icmp_type` is translated to API `icmp-type` key."""
+        rule = {"action": "ACCEPT", "type": "in", "icmp_type": "echo-request"}
+        payload = _build_create_rule_payload(rule, 0, GROUP_NAME)
+        assert payload["icmp-type"] == "echo-request"
+        assert "icmp_type" not in payload
+
+
+class TestBuildUpdateRulePayload:
+    def test_seeds_optional_fields_from_current(self):
+        """Update payload must preserve omitted optional fields from current rule."""
+        desired = {"action": "ACCEPT", "type": "in"}
+        current = {"action": "DROP", "type": "in", "enable": 1, "proto": "tcp", "dport": "80"}
+        payload = _build_update_rule_payload(desired, current)
+        assert payload["proto"] == "tcp"  # preserved from current
+        assert payload["dport"] == "80"  # preserved from current
+
+    def test_desired_overrides_current_action(self):
+        """Requested action must win over existing value during updates."""
+        desired = {"action": "DROP", "type": "in"}
+        current = {"action": "ACCEPT", "type": "in", "enable": 1}
+        payload = _build_update_rule_payload(desired, current)
+        assert payload["action"] == "DROP"
+
+    def test_desired_overrides_optional_field(self):
+        """Explicit optional fields from desired state must replace current values."""
+        desired = {"action": "ACCEPT", "type": "in", "dport": "443"}
+        current = {"action": "ACCEPT", "type": "in", "enable": 1, "dport": "80"}
+        payload = _build_update_rule_payload(desired, current)
+        assert payload["dport"] == "443"
+
+    def test_no_current_rule(self):
+        """Handle update payload creation when current rule is absent (defensive path)."""
+        desired = {"action": "ACCEPT", "type": "in", "dport": "80"}
+        payload = _build_update_rule_payload(desired, None)
+        assert payload["action"] == "ACCEPT"
+        assert payload["type"] == "in"
+        assert payload["dport"] == "80"
+
+
+class TestNormalizeForReturn:
+    def test_adds_enabled_default_when_absent(self):
+        """Check-mode return should include default enabled value for consistency."""
+        result = _normalize_for_return({"action": "ACCEPT", "type": "in"})
+        assert result["enabled"] is True
+
+    def test_preserves_explicit_enabled_false(self):
+        """Do not overwrite explicit disabled state while normalizing output."""
+        result = _normalize_for_return({"action": "ACCEPT", "type": "in", "enabled": False})
+        assert result["enabled"] is False
+
+    def test_preserves_other_fields(self):
+        """Normalization must not drop unrelated user-provided rule fields."""
+        result = _normalize_for_return({"action": "DROP", "type": "out", "dport": "80", "proto": "tcp"})
+        assert result["action"] == "DROP"
+        assert result["dport"] == "80"
+        assert result["proto"] == "tcp"
+
+    def test_does_not_mutate_input(self):
+        """Protect callers from side effects when normalizing return structures."""
+        rule = {"action": "ACCEPT", "type": "in"}
+        _normalize_for_return(rule)
+        assert "enabled" not in rule
+
+
+class TestPutRulePayload:
+    def test_strips_pos_ipversion_digest_group(self):
+        """PUT payload must omit immutable/unsupported fields rejected by Proxmox API."""
+        merged = {
+            "action": "ACCEPT",
+            "type": "in",
+            "enable": 1,
+            "pos": 2,
+            "ipversion": 4,
+            "digest": "abc123",
+            "group": "webserver",
+            "dport": "80",
+        }
+        result = _put_rule_payload(merged)
+        assert "pos" not in result
+        assert "ipversion" not in result
+        assert "digest" not in result
+        assert "group" not in result
+        assert result["action"] == "ACCEPT"
+        assert result["dport"] == "80"
+
+    def test_empty_dict(self):
+        """Empty payload handling should remain a safe no-op transformation."""
+        assert _put_rule_payload({}) == {}
+
+    def test_keeps_all_other_fields(self):
+        """Ensure sanitization only removes forbidden keys and preserves valid fields."""
+        merged = {"action": "DROP", "type": "out", "enable": 0, "proto": "tcp", "comment": "test"}
+        result = _put_rule_payload(merged)
+        assert result == merged
+
+
+class TestSortRules:
+    def test_sorts_ascending_by_pos(self):
+        """Rule fetch order must be deterministic for positional reconciliation logic."""
+        rules = [
+            {"pos": 2, "action": "DROP"},
+            {"pos": 0, "action": "ACCEPT"},
+            {"pos": 1, "action": "REJECT"},
+        ]
+        sorted_rules = _sort_rules(rules)
+        assert [r["pos"] for r in sorted_rules] == [0, 1, 2]
+
+    def test_already_sorted_unchanged(self):
+        """Sorting helper should be idempotent for already ordered API responses."""
+        rules = [{"pos": 0, "action": "ACCEPT"}, {"pos": 1, "action": "DROP"}]
+        assert _sort_rules(rules) == rules
+
+    def test_single_rule(self):
+        """Single-entry rule lists should remain unchanged by sorting helper."""
+        rules = [{"pos": 5, "action": "ACCEPT"}]
+        assert _sort_rules(rules) == rules
+
+
+# ---------------------------------------------------------------------------
+# Module integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestProxmoxClusterFirewallSecurityGroupModule(ModuleTestCase):
+    def setUp(self):
+        super().setUp()
+        self.module = proxmox_cluster_firewall_security_group
+        self.mock_module_helper = patch.multiple(
+            basic.AnsibleModule,
+            exit_json=exit_json,
+            fail_json=fail_json,
+        )
+        self.mock_module_helper.start()
+        self.connect_mock = patch(
+            "ansible_collections.community.proxmox.plugins.module_utils.proxmox.ProxmoxAnsible._connect",
+        ).start()
+
+        mock_api = self.connect_mock.return_value
+        fw = mock_api.cluster.return_value.firewall.return_value
+
+        self.groups_base = Mock()
+        self.groups_named = Mock()
+        self.rule_at_pos = Mock()
+        self.groups_named.return_value = self.rule_at_pos
+
+        fw.groups.side_effect = lambda *args: self.groups_named if args else self.groups_base
+
+    def tearDown(self):
+        self.connect_mock.stop()
+        self.mock_module_helper.stop()
+        super().tearDown()
+
+    def _run_module(self, args):
+        with pytest.raises(SystemExit) as exc_info, set_module_args(args):
+            self.module.main()
+        return exc_info.value.args[0]
+
+    def _check_mode(self, **kwargs):
+        return {**build_module_args(**kwargs), "_ansible_check_mode": True}
+
+    # -- state=absent ---------------------------------------------------------
+
+    def test_absent_when_group_not_found(self):
+        """Deleting a missing group must be idempotent and avoid delete API calls."""
+        self.groups_base.get.return_value = []
+
+        result = self._run_module(build_module_args(state="absent"))
+
+        assert result["changed"] is False
+        assert "does not exist" in result["msg"]
+        self.groups_named.delete.assert_not_called()
+
+    def test_absent_deletes_rules_then_group(self):
+        """Ensure delete flow removes rules first, then group, for API compatibility."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # initial fetch in _delete_rules
+            [],  # re-fetch after deletion → exits loop
+        ]
+
+        result = self._run_module(build_module_args(state="absent"))
+
+        assert result["changed"] is True
+        assert "successfully deleted" in result["msg"]
+        self.rule_at_pos.delete.assert_called_once()
+        self.groups_named.delete.assert_called_once()
+
+    def test_absent_deletes_multiple_rules_in_reverse_order(self):
+        """Verify repeated deletion loop handles multiple rules safely until empty."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0, SAMPLE_RULE_1],  # initial fetch
+            [SAMPLE_RULE_0],  # re-fetch after deleting pos=1
+            [],  # re-fetch after deleting pos=0
+        ]
+
+        self._run_module(build_module_args(state="absent"))
+
+        assert self.rule_at_pos.delete.call_count == 2  # noqa: PLR2004
+        self.groups_named.delete.assert_called_once()
+
+    def test_absent_deletes_group_with_no_rules(self):
+        """Delete path should still remove group when no child rules exist."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.return_value = []
+
+        result = self._run_module(build_module_args(state="absent"))
+
+        assert result["changed"] is True
+        self.rule_at_pos.delete.assert_not_called()
+        self.groups_named.delete.assert_called_once()
+
+    def test_absent_check_mode(self):
+        """Check mode should report deletion without performing destructive operations."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+
+        result = self._run_module(self._check_mode(state="absent"))
+
+        assert result["changed"] is True
+        assert "would be deleted" in result["msg"]
+        self.groups_named.delete.assert_not_called()
+        self.groups_base.post.assert_not_called()
+
+    # -- state=present, group does not exist ----------------------------------
+
+    def test_present_creates_group_without_rules(self):
+        """Create path without `rules` must manage only group/comment and skip rules."""
+        self.groups_base.get.return_value = []
+
+        result = self._run_module(build_module_args(comment="Managed by Ansible"))
+
+        assert result["changed"] is True
+        assert "successfully created" in result["msg"]
+        assert result["name"] == GROUP_NAME
+        assert result["comment"] == "Managed by Ansible"
+        assert "rules" not in result  # rules param was omitted
+        self.groups_base.post.assert_called_once()
+        self.groups_named.post.assert_not_called()
+
+    def test_present_creates_group_with_rules(self):
+        """Create path with rules should create both group and initial rules."""
+        self.groups_base.get.return_value = []
+        self.groups_named.get.return_value = [SAMPLE_RULE_0]
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        assert "successfully created" in result["msg"]
+        assert "rules" in result
+        assert len(result["rules"]) == 1
+        assert result["rules"][0]["action"] == "ACCEPT"
+        assert result["rules"][0]["enabled"] is True
+        self.groups_base.post.assert_called_once()
+        self.groups_named.post.assert_called_once()
+
+    def test_present_creates_group_with_multiple_rules(self):
+        """Multiple desired rules must produce one create call per rule."""
+        self.groups_base.get.return_value = []
+        self.groups_named.get.return_value = [SAMPLE_RULE_0, SAMPLE_RULE_1]
+
+        self._run_module(build_module_args(rules=[DESIRED_RULE_0, DESIRED_RULE_1]))
+
+        assert self.groups_named.post.call_count == 2  # noqa: PLR2004
+
+    def test_present_check_mode_create(self):
+        """Check mode create should preview resulting object while avoiding API writes."""
+        self.groups_base.get.return_value = []
+
+        result = self._run_module(self._check_mode(comment="Managed by Ansible", rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        assert "would be created" in result["msg"]
+        assert result["comment"] == "Managed by Ansible"
+        assert len(result["rules"]) == 1
+        assert result["rules"][0]["action"] == "ACCEPT"
+        assert result["rules"][0]["enabled"] is True
+        self.groups_base.post.assert_not_called()
+        self.groups_named.post.assert_not_called()
+
+    def test_present_check_mode_create_without_rules(self):
+        """Check mode should preserve omitted-rules semantics (no synthetic rules list)."""
+        self.groups_base.get.return_value = []
+
+        result = self._run_module(self._check_mode())
+
+        assert result["changed"] is True
+        assert result.get("rules") is None
+        self.groups_base.post.assert_not_called()
+
+    # -- state=present, group exists ------------------------------------------
+
+    def test_present_idempotent_no_params(self):
+        """Existing group with no desired changes should return unchanged and no writes."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+
+        result = self._run_module(build_module_args())
+
+        assert result["changed"] is False
+        assert "already in desired state" in result["msg"]
+        assert result["comment"] == SAMPLE_GROUP["comment"]
+        assert "rules" not in result
+        self.groups_base.post.assert_not_called()
+        self.groups_named.post.assert_not_called()
+
+    def test_present_idempotent_comment_matches(self):
+        """Matching comment should not trigger needless group update call."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+
+        result = self._run_module(build_module_args(comment="Managed by Ansible"))
+
+        assert result["changed"] is False
+        self.groups_base.post.assert_not_called()
+
+    def test_present_updates_comment(self):
+        """Comment drift must trigger update and return new comment value."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+
+        result = self._run_module(build_module_args(comment="New comment"))
+
+        assert result["changed"] is True
+        assert "successfully updated" in result["msg"]
+        assert result["comment"] == "New comment"
+        self.groups_base.post.assert_called_once()
+
+    def test_present_idempotent_rules_match(self):
+        """Matching rules should not trigger post/put/delete reconciliation actions."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # _rules_would_change
+            [SAMPLE_RULE_0],  # _prune_excess_rules
+            [SAMPLE_RULE_0],  # final fetch
+        ]
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is False
+        assert "rules" in result
+        assert result["rules"][0]["pos"] == 0
+        self.groups_named.post.assert_not_called()
+        self.rule_at_pos.put.assert_not_called()
+        self.rule_at_pos.delete.assert_not_called()
+
+    def test_present_prunes_excess_rules(self):
+        """When desired list is shorter, extra existing rules must be pruned."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0, SAMPLE_RULE_1],  # _rules_would_change (count differs)
+            [SAMPLE_RULE_0, SAMPLE_RULE_1],  # _prune_excess_rules initial fetch
+            [SAMPLE_RULE_0],  # _prune_excess_rules after deletion
+            [SAMPLE_RULE_0],  # final fetch
+        ]
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        self.rule_at_pos.delete.assert_called_once()
+        assert len(result["rules"]) == 1
+
+    def test_present_updates_rule_in_place(self):
+        """Rule content drift in shared prefix should trigger PUT, not recreate."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        updated_rule = {**SAMPLE_RULE_0, "dport": "8080"}
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # _rules_would_change (content differs)
+            [SAMPLE_RULE_0],  # _prune_excess_rules
+            [updated_rule],  # final fetch
+        ]
+
+        result = self._run_module(build_module_args(rules=[{**DESIRED_RULE_0, "dport": "8080"}]))
+
+        assert result["changed"] is True
+        self.rule_at_pos.put.assert_called_once()
+        self.rule_at_pos.delete.assert_not_called()
+        assert result["rules"][0]["dport"] == "8080"
+
+    def test_present_creates_trailing_rule(self):
+        """When desired list grows, missing trailing rules must be created."""
+        # Start with no rules, add one.
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [],  # _rules_would_change (count differs)
+            [],  # _prune_excess_rules
+            [SAMPLE_RULE_0],  # _create_missing_trailing_rules after POST
+            [SAMPLE_RULE_0],  # final fetch
+        ]
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        self.groups_named.post.assert_called_once()
+        assert len(result["rules"]) == 1
+
+    def test_present_updates_comment_and_rules(self):
+        """Combined drift should update both group metadata and rule set in one run."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [],  # _rules_would_change
+            [],  # _prune_excess_rules
+            [SAMPLE_RULE_0],  # _create_missing_trailing_rules after POST
+            [SAMPLE_RULE_0],  # final fetch
+        ]
+
+        result = self._run_module(build_module_args(comment="New comment", rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        assert result["comment"] == "New comment"
+        assert len(result["rules"]) == 1
+        self.groups_base.post.assert_called_once()  # comment update
+        self.groups_named.post.assert_called_once()  # rule create
+
+    def test_present_check_mode_no_change(self):
+        """No-op check mode should return current normalized rules without side effects."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # _rules_would_change
+            [SAMPLE_RULE_0],  # check mode result fetch
+        ]
+
+        result = self._run_module(self._check_mode(comment="Managed by Ansible", rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is False
+        assert "already in desired state" in result["msg"]
+        assert result["comment"] == SAMPLE_GROUP["comment"]
+        assert result["rules"][0]["pos"] == 0  # API fields present
+        assert result["rules"][0]["enabled"] is True  # enable→enabled conversion
+        self.groups_base.post.assert_not_called()
+        self.groups_named.post.assert_not_called()
+
+    def test_present_check_mode_would_update_comment(self):
+        """Check mode must flag pending comment update without API mutation."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+
+        result = self._run_module(self._check_mode(comment="New comment"))
+
+        assert result["changed"] is True
+        assert "would be updated" in result["msg"]
+        assert result["comment"] == "New comment"
+        self.groups_base.post.assert_not_called()
+
+    def test_present_check_mode_would_update_rules(self):
+        """Check mode must flag pending rule reconciliation and preview desired rules."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.return_value = []  # empty → count differs
+
+        result = self._run_module(self._check_mode(rules=[DESIRED_RULE_0]))
+
+        assert result["changed"] is True
+        assert "would be updated" in result["msg"]
+        assert len(result["rules"]) == 1
+        assert result["rules"][0]["enabled"] is True
+        self.groups_named.post.assert_not_called()
+
+    # -- API error handling ---------------------------------------------------
+
+    def test_fetch_groups_api_error(self):
+        """Surface group read failures with module-specific, actionable error message."""
+        self.groups_base.get.side_effect = Exception("connection refused")
+
+        result = self._run_module(build_module_args())
+
+        assert result.get("failed") is True
+        assert "Failed to read firewall security groups" in result["msg"]
+
+    def test_create_group_api_error(self):
+        """Surface group create failures instead of silently continuing."""
+        self.groups_base.get.return_value = []
+        self.groups_base.post.side_effect = Exception("unauthorized")
+
+        result = self._run_module(build_module_args())
+
+        assert result.get("failed") is True
+        assert "Failed to create firewall security group" in result["msg"]
+
+    def test_create_rule_api_error(self):
+        """Surface rule create failures from create workflow with clear context."""
+        self.groups_base.get.return_value = []
+        self.groups_named.post.side_effect = Exception("rule rejected")
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result.get("failed") is True
+        assert "Failed to create firewall rule" in result["msg"]
+
+    def test_fetch_rules_api_error(self):
+        """Surface rule read failures during reconcile to stop unsafe updates."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = Exception("timeout")
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result.get("failed") is True
+        assert "Failed to read firewall rules" in result["msg"]
+
+    def test_update_group_comment_api_error(self):
+        """Surface comment update failures so partial updates are visible."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_base.post.side_effect = Exception("unauthorized")
+
+        result = self._run_module(build_module_args(comment="New comment"))
+
+        assert result.get("failed") is True
+        assert "Failed to update firewall security group" in result["msg"]
+
+    def test_delete_group_api_error(self):
+        """Surface group delete failures for absent workflow reliability."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.return_value = []
+        self.groups_named.delete.side_effect = Exception("forbidden")
+
+        result = self._run_module(build_module_args(state="absent"))
+
+        assert result.get("failed") is True
+        assert "Failed to delete firewall security group" in result["msg"]
+
+    def test_delete_rules_api_error(self):
+        """Surface individual rule delete failures instead of looping indefinitely."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.return_value = [SAMPLE_RULE_0]
+        self.rule_at_pos.delete.side_effect = Exception("server error")
+
+        result = self._run_module(build_module_args(state="absent"))
+
+        assert result.get("failed") is True
+        assert "Failed to delete firewall rule" in result["msg"]
+
+    def test_prune_excess_rules_api_error(self):
+        """Surface failures while pruning extra rules during reconcile."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0, SAMPLE_RULE_1],  # _rules_would_change (count differs)
+            [SAMPLE_RULE_0, SAMPLE_RULE_1],  # _prune_excess_rules initial fetch
+        ]
+        self.rule_at_pos.delete.side_effect = Exception("conflict")
+
+        result = self._run_module(build_module_args(rules=[DESIRED_RULE_0]))
+
+        assert result.get("failed") is True
+        assert "Failed to delete firewall rule" in result["msg"]
+
+    def test_update_rule_in_prefix_api_error(self):
+        """Surface failures when updating existing prefix rules via PUT."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.side_effect = [
+            [SAMPLE_RULE_0],  # _rules_would_change (content differs)
+            [SAMPLE_RULE_0],  # _prune_excess_rules
+        ]
+        self.rule_at_pos.put.side_effect = Exception("conflict")
+
+        result = self._run_module(build_module_args(rules=[{**DESIRED_RULE_0, "dport": "8080"}]))
+
+        assert result.get("failed") is True
+        assert "Failed to update firewall rule" in result["msg"]
+
+    # -- missing behavioural scenarios ----------------------------------------
+
+    def test_absent_check_mode_when_group_not_found(self):
+        """Check-mode delete of missing group should stay unchanged and side-effect free."""
+        self.groups_base.get.return_value = []
+
+        result = self._run_module(self._check_mode(state="absent"))
+
+        assert result["changed"] is False
+        assert "does not exist" in result["msg"]
+        self.groups_named.delete.assert_not_called()
+        self.groups_base.post.assert_not_called()
+
+    def test_present_check_mode_update_rule_in_place(self):
+        """Check mode when count is unchanged but rule content differs."""
+        self.groups_base.get.return_value = [SAMPLE_GROUP]
+        self.groups_named.get.return_value = [SAMPLE_RULE_0]  # current: dport=80
+
+        result = self._run_module(self._check_mode(rules=[{**DESIRED_RULE_0, "dport": "8080"}]))
+
+        assert result["changed"] is True
+        assert "would be updated" in result["msg"]
+        assert result["rules"][0]["dport"] == "8080"
+        self.rule_at_pos.put.assert_not_called()
+        self.groups_named.post.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

Add new module `proxmox_cluster_firewall_security_group`, dedicated module for cluster security groups.

Related to: https://github.com/ansible-collections/community.proxmox/issues/300

This extraction from `proxmox_firewall` comes with key beneficts:

- supports full check mode
- provides a clear declarative rules model:
  - `rules` omitted = keep existing rules untouched
  - `rules: []` = remove all rules
  - `rules: [...]` = reconcile full ordered ruleset (list index = rule position

Some "side" beneficts:

- support updating the security group comment
- support deleting a security group with existing rules by removing them first
- no "pos" required in rules
- retry logic to handle put concurrency issue (tested and can occur when patching large amount of rules)

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

`proxmox_cluster_firewall_security_group`

##### ADDITIONAL INFORMATION

Unit and integration tests were generated with AI and reviewed/adjusted manually.