### PR TITLE
fix(proxmox_pool): nested pool support

### DIFF
--- a/changelogs/fragments/315-storage-validation-required-options.yml
+++ b/changelogs/fragments/315-storage-validation-required-options.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - proxmox_storage - when ``state=present`` parameters ``content`` and ``nodes`` are now not required (https://github.com/ansible-collections/community.proxmox/pull/315).
+bugfixes:
+  - proxmox_storage - backend ``cephfs``, ``dir`` and ``zfspool`` doesn't requires ``content`` parameter (https://github.com/ansible-collections/community.proxmox/pull/315).

--- a/changelogs/fragments/316-support-nested-pool.yml
+++ b/changelogs/fragments/316-support-nested-pool.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_pool - support nested pool (https://github.com/ansible-collections/community.proxmox/pull/316).

--- a/changelogs/fragments/319-fix-efidisk-tpmstate.yaml
+++ b/changelogs/fragments/319-fix-efidisk-tpmstate.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_disk - add support for efidisk and tpmstate disk bus types which previously caused module failure with "Unsupported disk bus" error (https://github.com/ansible-collections/community.proxmox/pull/319).

--- a/changelogs/fragments/426-fix-nested-pool.yaml
+++ b/changelogs/fragments/426-fix-nested-pool.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_pool - fix nested pool support (https://github.com/ansible-collections/community.proxmox/pull/426).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: proxmox
-version: 2.0.0-beta01
+version: 1.6.1
 readme: README.md
 authors:
   - Ansible community (https://github.com/ansible-community)

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -365,7 +365,7 @@ class ProxmoxAnsible:
             dict: Pool information.
         """
         try:
-            return self.proxmox_api.pools(poolid).get()
+            return self.proxmox_api.pools.get(poolid=poolid)
         except Exception as e:
             self.module.fail_json(msg=f"Unable to retrieve pool {poolid} information: {e}")
 

--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -29,9 +29,9 @@ options:
     type: int
   disk:
     description:
-      - The disk key (V(unused[n]), V(ide[n]), V(sata[n]), V(scsi[n]) or V(virtio[n])) you want to operate on.
+      - The disk key (V(unused[n]), V(ide[n]), V(sata[n]), V(scsi[n]), V(virtio[n]), V(efidisk[n]) or V(tpmstate[n])) you want to operate on.
       - Disk buses (IDE, SATA and so on) have fixed ranges of V(n) that accepted by Proxmox API.
-      - 'For IDE: 0-3; for SCSI: 0-30; for SATA: 0-5; for VirtIO: 0-15; for Unused: 0-255.'
+      - 'For IDE: 0-3; for SCSI: 0-30; for SATA: 0-5; for VirtIO: 0-15; for Unused: 0-255; for EFI disk: 0; for TPM state: 0.'
     type: str
     required: true
   state:
@@ -533,7 +533,7 @@ class ProxmoxDiskAnsible(ProxmoxAnsible):
         "wwn",
     ]
     supported_bus_num_ranges = dict(
-        ide=range(0, 4), scsi=range(0, 31), sata=range(0, 6), virtio=range(0, 16), unused=range(0, 256)
+        ide=range(0, 4), scsi=range(0, 31), sata=range(0, 6), virtio=range(0, 16), unused=range(0, 256), efidisk=range(0, 1), tpmstate=range(0, 1)
     )
 
     def get_create_attributes(self):

--- a/plugins/modules/proxmox_pool.py
+++ b/plugins/modules/proxmox_pool.py
@@ -90,7 +90,7 @@ class ProxmoxPoolAnsible(ProxmoxAnsible):
         :return: bool - is pool exists?
         """
         try:
-            self.proxmox_api.pools(poolid).get()
+            self.proxmox_api.pools.get(poolid=poolid)
             return True
         except Exception as e:
             error_str = str(e).lower()
@@ -138,7 +138,7 @@ class ProxmoxPoolAnsible(ProxmoxAnsible):
                 return
 
             try:
-                self.proxmox_api.pools(poolid).delete()
+                self.proxmox_api.pools.delete(poolid=poolid)
             except Exception as e:
                 self.module.fail_json(msg=f"Failed to delete pool with ID {poolid}: {e}")
         else:

--- a/plugins/modules/proxmox_storage.py
+++ b/plugins/modules/proxmox_storage.py
@@ -21,7 +21,6 @@ options:
   nodes:
     description:
       - A list of Proxmox VE nodes on which the target storage is enabled.
-      - Required when C(state=present).
     type: list
     elements: str
     required: false
@@ -220,7 +219,6 @@ options:
   content:
     description:
       - The desired content that should be used with this storage type.
-      - Required when C(state=present).
     type: list
     required: false
     elements: str
@@ -320,16 +318,15 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
 )
 
 STORAGE_REQUIRED_OPTIONS = {
-    "cephfs": (["content"], "CephFS storage requires 'content' option."),
     "cifs": (["server", "share"], "CIFS storage requires 'server' and 'share' options."),
-    "dir": (["path", "content"], "Directory storage requires 'path' and 'content' options."),
+    "dir": (["path"], "Directory storage requires 'path' option."),
     "iscsi": (["portal", "target"], "iSCSI storage requires 'portal' and 'target' options."),
     "nfs": (["server", "export"], "NFS storage requires 'server' and 'export' options."),
     "pbs": (
         ["server", "username", "password", "datastore"],
         "PBS storage requires 'server', 'username', 'password' and 'datastore' options.",
     ),
-    "zfspool": (["pool", "content"], "ZFS storage requires 'pool' and 'content' options."),
+    "zfspool": (["pool"], "ZFS storage requires 'pool' option."),
 }
 
 
@@ -351,7 +348,13 @@ class ProxmoxNodeAnsible(ProxmoxAnsible):
         content = self.module.params.get("content")
 
         # Create payload for storage creation
-        payload = {"storage": storage_name, "type": storage_type, "nodes": nodes, "content": content}
+        payload = {"storage": storage_name, "type": storage_type}
+
+        if nodes:
+            payload["nodes"] = nodes
+
+        if content:
+            payload["content"] = content
 
         # Validate required parameters based on storage type
         if storage_type == "cephfs":
@@ -594,7 +597,6 @@ def main():
         required_one_of=[("api_password", "api_token_id")],
         required_together=[("api_token_id", "api_token_secret")],
         supports_check_mode=True,
-        required_if=[["state", "present", ["nodes", "content"]]],
     )
 
     # Initialize objects and avoid re-polling the current

--- a/tests/unit/plugins/modules/test_proxmox_storage.py
+++ b/tests/unit/plugins/modules/test_proxmox_storage.py
@@ -318,14 +318,10 @@ def test_validate_zfspool_missing_required_options():
     assert "pool" in str(exc.value)
 
 
-def test_validate_cephfs_missing_required_options():
-    cephfs_options = {}  # Missing 'content' parameter
+def test_validate_cephfs_no_required_options_does_not_raise():
+    cephfs_options = {}
 
-    with pytest.raises(AnsibleValidationError) as exc:
-        validate_storage_type_options("cephfs", cephfs_options)
-
-    assert "CephFS storage requires" in str(exc.value)
-    assert "content" in str(exc.value)
+    validate_storage_type_options("cephfs", cephfs_options)
 
 
 def test_validate_cifs_missing_required_options():
@@ -359,3 +355,31 @@ def test_validate_nfs_missing_required_options():
     assert "NFS storage requires" in str(exc.value)
     assert "server" in str(exc.value)
     assert "export" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        "cephfs",
+        "cifs",
+        "dir",
+        "iscsi",
+        "nfs",
+        "pbs",
+        "zfspool",
+    ],
+)
+def test_storage_validation_never_requires_content_or_nodes(storage_type):
+    if storage_type in proxmox_storage.STORAGE_REQUIRED_OPTIONS:
+        required_fields, error_msg = proxmox_storage.STORAGE_REQUIRED_OPTIONS[storage_type]
+        assert "content" not in required_fields
+        assert "nodes" not in required_fields
+        assert "content" not in error_msg.lower()
+        assert "nodes" not in error_msg.lower()
+
+    try:
+        validate_storage_type_options(storage_type, {})
+    except AnsibleValidationError as exc:
+        msg = str(exc).lower()
+        assert "content" not in msg
+        assert "nodes" not in msg


### PR DESCRIPTION
##### SUMMARY

Regression from 1.5.0 to 1.6.0, this PR fixes `proxmox_pool` to support nested pool.

This issue is already fixed in 2.0.0.

Fixes #426

Related to: #316 on 2.0.0

Introduced here: #307 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

 `proxmox_pool` 

##### ADDITIONAL INFORMATION

The PR branch source is 1.6.0.

How should we handle this fixes? Wait for 2.0.0 for create a new version 1.6.1? Or something else. Let me know!

We can close this PR if we don't plan to do a backport.


