### PR TITLE
fix(proxmox_pool_member): fix membership updates and nested pool support

### DIFF
--- a/changelogs/fragments/428-proxmox-pool-member.yml
+++ b/changelogs/fragments/428-proxmox-pool-member.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox_pool_member - fix pool membership update (https://github.com/ansible-collections/community.proxmox/pull/428).
+  - proxmox_pool_member - fix pool membership operations failing for nested pool IDs (https://github.com/ansible-collections/community.proxmox/pull/428).

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -259,7 +259,7 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
             payload["delete"] = 1
 
         try:
-            self.proxmox_api.pools(poolid).put(payload)
+            self.proxmox_api.pools.put(poolid=poolid, **payload)
         except Exception as e:
             self.module.fail_json(msg=f"Failed to update pool {poolid} membership: {e}")
 

--- a/tests/integration/targets/proxmox_pool/defaults/main.yml
+++ b/tests/integration/targets/proxmox_pool/defaults/main.yml
@@ -4,4 +4,4 @@
 
 poolid: test
 member: local
-member_type: storage
+nested_poolid: "{{ poolid }}/test-nested"

--- a/tests/integration/targets/proxmox_pool/tasks/main.yml
+++ b/tests/integration/targets/proxmox_pool/tasks/main.yml
@@ -12,92 +12,242 @@
   environment: "{{ environment_auth_vars }}"
 
   block:
-    - name: Make sure poolid parameter is not missing
-      proxmox_pool:
-      ignore_errors: true
-      register: result
-
-    - assert:
-        that:
-          - result is failed
-          - "'missing required arguments: poolid' in result.msg"
-
-    - name: Create pool (Check)
-      proxmox_pool:
-        poolid: "{{ poolid }}"
-      check_mode: true
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-          - result is success
-
-    - name: Create pool
-      proxmox_pool:
-        poolid: "{{ poolid }}"
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-          - result is success
-          - result.poolid == "{{ poolid }}"
-
-    - name: Delete pool (Check)
-      proxmox_pool:
-        poolid: "{{ poolid }}"
-        state: absent
-      check_mode: true
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-          - result is success
-
-    - name: Delete non-existing pool should do nothing
-      proxmox_pool:
-        poolid: "non-existing-poolid"
-        state: absent
-      register: result
-
-    - assert:
-        that:
-          - result is not changed
-          - result is success
-
-    - name: Deletion of non-empty pool fails
+    - name: Ensure clean state before starting
       block:
-        - name: Add storage into pool
-          proxmox_pool_member:
+        - name: Delete nested pool if left from previous run
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+            state: absent
+          ignore_errors: true
+
+        - name: Delete test pool if left from previous run
+          community.proxmox.proxmox_pool:
             poolid: "{{ poolid }}"
-            member: "{{ member }}"
-            type: "{{ member_type }}"
-          diff: true
+            state: absent
+          ignore_errors: true
+
+    - name: Pool lifecycle for base pool
+      block:
+        - name: Create pool in check mode
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+          check_mode: true
           register: result
 
         - assert:
             that:
               - result is changed
               - result is success
-              - "'{{ member }}' in result.diff.after.members"
 
-        - name: Add non-existing storage into pool should fail
-          proxmox_pool_member:
+        - name: Verify check mode did not create pool
+          community.proxmox.proxmox_pool:
             poolid: "{{ poolid }}"
-            member: "non-existing-storage"
-            type: "{{ member_type }}"
+            state: absent
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Create pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - result.poolid == poolid
+
+        - name: Create pool idempotently
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+    - name: Pool member lifecycle and reconciliation
+      block:
+        - name: Add storage member in check mode
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          check_mode: true
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Verify check mode did not add storage member
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            state: absent
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Add storage member
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Add storage member idempotently
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Remove storage member in check mode
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            state: absent
+            members:
+              - storage: "{{ member }}"
+          check_mode: true
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Verify check mode did not remove storage member
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Remove storage member
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            state: absent
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Remove storage member idempotently
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            state: absent
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Add non-existing storage to pool fails
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "non-existing-storage"
           ignore_errors: true
           register: result
 
         - assert:
             that:
               - result is failed
-              - "'Storage non-existing-storage doesn\\'t exist in the cluster' in result.msg"
+              - "'non-existing-storage' in result.msg"
 
-        - name: Delete non-empty pool
-          proxmox_pool:
+        - name: Add storage member for exclusive mode and delete guard checks
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Reconcile members to empty set with exclusive mode
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            exclusive: true
+            members: []
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Reconcile members to empty set idempotently
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            exclusive: true
+            members: []
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Add storage member again for non-empty delete guard
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Delete non-empty pool fails
+          community.proxmox.proxmox_pool:
             poolid: "{{ poolid }}"
             state: absent
           ignore_errors: true
@@ -108,43 +258,230 @@
               - result is failed
               - "'Please remove members from pool first.' in result.msg"
 
-        - name: Delete storage from the pool
-          proxmox_pool_member:
+        - name: Empty pool using exclusive mode before deletion
+          community.proxmox.proxmox_pool_member:
             poolid: "{{ poolid }}"
-            member: "{{ member }}"
-            type: "{{ member_type }}"
+            exclusive: true
+            members: []
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "result.members | length == 0"
+
+      rescue:
+        - name: Best-effort cleanup of pool members after member test failure
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ poolid }}"
+            exclusive: true
+            members: []
+          ignore_errors: true
+
+    - name: Nested pool ID lifecycle
+      block:
+        - name: Create nested pool in check mode
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+          check_mode: true
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+
+        - name: Verify check mode did not create nested pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
             state: absent
           register: result
 
         - assert:
             that:
+              - result is not changed
               - result is success
+
+        - name: Create nested pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+          register: result
+
+        - assert:
+            that:
               - result is changed
+              - result is success
+              - result.poolid == nested_poolid
+
+        - name: Create nested pool idempotently
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Add member to nested pool
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ nested_poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "{'storage': member} in result.members"
+
+        - name: Add member to nested pool idempotently
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ nested_poolid }}"
+            members:
+              - storage: "{{ member }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Delete non-empty nested pool fails
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+            state: absent
+          ignore_errors: true
+          register: result
+
+        - assert:
+            that:
+              - result is failed
+              - "'Please remove members from pool first.' in result.msg"
+
+        - name: Empty nested pool members with exclusive mode
+          community.proxmox.proxmox_pool_member:
+            poolid: "{{ nested_poolid }}"
+            exclusive: true
+            members: []
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - "result.members | length == 0"
+
+        - name: Delete nested pool in check mode
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+            state: absent
+          check_mode: true
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+
+        - name: Verify check mode did not delete nested pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Delete nested pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+            state: absent
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - result.poolid == nested_poolid
+
+        - name: Delete nested pool idempotently
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
+            state: absent
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
 
       rescue:
-        - name: Delete storage from the pool if it is added
-          proxmox_pool_member:
-            poolid: "{{ poolid }}"
-            member: "{{ member }}"
-            type: "{{ member_type }}"
+        - name: Best-effort cleanup of nested pool after failure
+          community.proxmox.proxmox_pool:
+            poolid: "{{ nested_poolid }}"
             state: absent
           ignore_errors: true
 
-    - name: Delete pool
-      proxmox_pool:
-        poolid: "{{ poolid }}"
-        state: absent
-      register: result
+    - name: Delete base pool lifecycle
+      block:
+        - name: Delete base pool in check mode
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+            state: absent
+          check_mode: true
+          register: result
 
-    - assert:
-        that:
-          - result is changed
-          - result is success
-          - result.poolid == "{{ poolid }}"
+        - assert:
+            that:
+              - result is changed
+              - result is success
+
+        - name: Verify check mode did not delete base pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
+
+        - name: Delete base pool
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+            state: absent
+          register: result
+
+        - assert:
+            that:
+              - result is changed
+              - result is success
+              - result.poolid == poolid
+
+        - name: Delete non-existing pool idempotently
+          community.proxmox.proxmox_pool:
+            poolid: "{{ poolid }}"
+            state: absent
+          register: result
+
+        - assert:
+            that:
+              - result is not changed
+              - result is success
 
   rescue:
-    - name: Delete test pool if it is created
-      proxmox_pool:
+    - name: Remove nested pool after top-level failure
+      community.proxmox.proxmox_pool:
+        poolid: "{{ nested_poolid }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete test pool after top-level failure
+      community.proxmox.proxmox_pool:
         poolid: "{{ poolid }}"
         state: absent
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Currently the module `proxmox_pool_member` doesn't support updating membership, the put payload is wrong:

```json
{
  "changed": false,
  "msg": "Failed to update pool test membership: 501 Not Implemented: Method 'PUT /pools/test/{'storage': ['local']}' not implemented"
}
```

And it's doesn't also support updating membership on nested pool.

This PR fixes these bugs and update integration tests (which cover these two bugs).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_pool_member`
