### PR TITLE
fix(proxmox_sdn): add missing none guard on get_ip_sets

### DIFF
--- a/changelogs/fragments/430-proxmox-firewall-info-handle-none.yml
+++ b/changelogs/fragments/430-proxmox-firewall-info-handle-none.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox_firewall_info - add none guard on get_ip_sets to prevent crash with ``'NoneType' object has no attribute 'ipset'`` when using ``level=group`` (https://github.com/ansible-collections/community.proxmox/issues/430).

--- a/plugins/module_utils/proxmox_sdn.py
+++ b/plugins/module_utils/proxmox_sdn.py
@@ -142,6 +142,8 @@ class ProxmoxSdnAnsible(ProxmoxAnsible):
 
         :return: dict of ip_set name and cidr
         """
+        if firewall_obj is None:
+            return list()
         try:
             ip_sets = firewall_obj.ipset().get()
             for ip_set in ip_sets:


### PR DESCRIPTION
##### SUMMARY

Add none guard on `get_ip_sets` to prevent bug when `level=group`.

Fixes https://github.com/ansible-collections/community.proxmox/issues/431
Regression introduce here https://github.com/ansible-collections/community.proxmox/pull/248

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_firewall_info`
