### PR TITLE
fix(proxmox_pool): nested pool support

### DIFF
--- a/changelogs/fragments/426-fix-nested-pool.yaml
+++ b/changelogs/fragments/426-fix-nested-pool.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_pool - fix nested pool support (https://github.com/ansible-collections/community.proxmox/pull/426).

--- a/plugins/modules/proxmox_pool.py
+++ b/plugins/modules/proxmox_pool.py
@@ -90,7 +90,7 @@ class ProxmoxPoolAnsible(ProxmoxAnsible):
         :return: bool - is pool exists?
         """
         try:
-            self.proxmox_api.pools(poolid).get()
+            self.proxmox_api.pools.get(poolid=poolid)
             return True
         except Exception as e:
             error_str = str(e).lower()
@@ -138,7 +138,7 @@ class ProxmoxPoolAnsible(ProxmoxAnsible):
                 return
 
             try:
-                self.proxmox_api.pools(poolid).delete()
+                self.proxmox_api.pools.delete(poolid=poolid)
             except Exception as e:
                 self.module.fail_json(msg=f"Failed to delete pool with ID {poolid}: {e}")
         else:


### PR DESCRIPTION
##### SUMMARY

Regression from 1.5.0 to 1.6.0, this PR fixes `proxmox_pool` to support nested pool.

Original PR: #427

This issue is already fixed in 2.0.0.

Fixes #426

Related to: #316 on 2.0.0

Introduced here: #307 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

 `proxmox_pool`

