### PR TITLE
docs(proxmox_kvm): fix net param doc ref link

### DIFF
--- a/plugins/modules/proxmox_kvm.py
+++ b/plugins/modules/proxmox_kvm.py
@@ -299,7 +299,7 @@ options:
       - V(macaddr=XX:XX:XX:XX:XX:XX) must be a unique MAC address.
         If not specified, a unique MAC address is automatically generated.
       - For a complete list of all available options, please refer to the Proxmox VE documentation (look for "net[n]:") at
-        U(https://pve.proxmox.com/pve-docs/chapter-qm.html\#qm_options).
+        U(https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_options).
     type: dict
   newid:
     description:


### PR DESCRIPTION
##### SUMMARY

Broken link in the documentation for community.proxmox.proxmox_kvm module on v1.6.0.

This is already fixed on main branch, the PR is to backport it, if it's not desired, be free to close this PR.

Fixes: #423

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_kvm`
