### PR TITLE
Fix typo in proxmox_disk documentation

### DIFF
--- a/plugins/modules/proxmox_disk.py
+++ b/plugins/modules/proxmox_disk.py
@@ -99,7 +99,7 @@ options:
     description:
       - The (unique) ID of the VM where disk will be placed when O(state=moved).
       - You can move disk between VMs only when the same storage is used.
-      - Mutually exclusive with O(target_vmid).
+      - Mutually exclusive with O(target_storage).
     type: int
   timeout:
     description:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`target_vmid` was listed as being mutually exclusive with itself in the documentation. Updated to correctly list it as mutually exclusive with `target_storage`.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Link to error in docs: https://docs.ansible.com/projects/ansible/latest/collections/community/proxmox/proxmox_disk_module.html#parameter-target_vmid
<!--- Paste verbatim command output below, e.g. before and after your change -->

