### PR TITLE
feat(domain): add openid audiences parameter

### DIFF
--- a/changelogs/fragments/437-add-openid-audiences-parameter.yaml
+++ b/changelogs/fragments/437-add-openid-audiences-parameter.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - proxmox_domain - Add ``openid_audiences`` parameter introduced in Proxmox VE 9.2 (https://github.com/ansible-collections/community.proxmox/pull/437).
+  - proxmox_domain - add ``openid_audiences`` parameter introduced in Proxmox VE 9.2 (https://github.com/ansible-collections/community.proxmox/pull/437).

--- a/changelogs/fragments/437-add-openid-audiences-parameter.yaml
+++ b/changelogs/fragments/437-add-openid-audiences-parameter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_domain - Add ``openid_audiences`` parameter introduced in Proxmox VE 9.2 (https://github.com/ansible-collections/community.proxmox/pull/437).

--- a/plugins/modules/proxmox_domain.py
+++ b/plugins/modules/proxmox_domain.py
@@ -20,6 +20,11 @@ attributes:
     support: none
 
 options:
+    openid_audiences:
+        description:
+            - A list of audiences that the OpenID Issuer may include that are accepted in addition to C(openid_client_id).
+            - Supported for O(type=openid).
+        type: str
     openid_acr_values:
         description:
             - Defines the Authentication Context Class Reference values requested from the Authorization Server for the Authentication Request.
@@ -328,6 +333,7 @@ def module_args():
                 "scope": dict(choices=["users", "groups", "both"]),
             },
         ),
+        openid_audiences=dict(type="str"),
         openid_acr_values=dict(type="str"),
         openid_autocreate=dict(type="bool"),
         openid_client_id=dict(type="str"),
@@ -446,6 +452,7 @@ class ProxmoxDomainAnsible(ProxmoxAnsible):
 
     def get_openid_params(self):
         list_openid_params = [
+            "openid_audiences",
             "openid_acr_values",
             "openid_autocreate",
             "openid_client_id",


### PR DESCRIPTION
##### SUMMARY

Add parameter `openid_audiences` for openid realm.

This parameter has been added in Proxmox 9.2: https://bugzilla.proxmox.com/show_bug.cgi?id=5076

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`proxmox_domain`
