### PR TITLE
docs(storage): remove invalid option from pbs storage example

### DIFF
--- a/plugins/modules/proxmox_storage.py
+++ b/plugins/modules/proxmox_storage.py
@@ -266,7 +266,6 @@ EXAMPLES = r"""
       password: password123
       datastore: backup
       fingerprint: "F3:04:D2:C1:33:B7:35:B9:88:D8:7A:24:85:21:DC:75:EE:7C:A5:2A:55:2D:99:38:6B:48:5E:CA:0D:E3:FE:66"
-      export: "/mnt/storage01/b01pbs01"
     content: ["backup"]
 
 - name: Add NFS storage to Proxmox VE Cluster


### PR DESCRIPTION
##### SUMMARY

While working on `proxmox_storage` I notice that in the example for `pbs` there is `export` option which is not a valid option for this storage type.

I haven't add a changelog fragment for this changes, let me know if it's required.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`proxmox_storage`