### PR TITLE
docs: add guidances for ai coding agents

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -19,6 +19,7 @@ Run and write tests for the `community.proxmox` Ansible collection. Covers sanit
 
 Use this order unless the user requests otherwise:
 
+0. After editing Python files, format before running tests: `nox -Re formatters`
 1. Run sanity or targeted unit tests for changed files first.
 2. Expand to broader unit coverage only if needed.
 3. Run integration tests only when behavior changed and a Proxmox environment is configured.
@@ -51,6 +52,12 @@ Most Proxmox integration targets are marked `unsupported` and require a real Pro
 ### Preferred (CI-aligned): nox
 
 ```bash
+# format (run after editing Python; CI lint gate)
+nox -Re formatters
+
+# verify lint without auto-fix (optional)
+nox -Re codeqa
+
 # sanity
 nox -Re ansible-test-sanity-devel
 
@@ -96,6 +103,7 @@ Integration tests live under `tests/integration/targets/<target_name>/`.
 
 ## Test Expectations
 
+- Python code changes: run `nox -Re formatters` before tests.
 - Documentation-only changes: run sanity tests.
 - Code changes: run sanity and targeted unit tests at minimum.
 - Behavior changes in modules: also run targeted integration tests when a Proxmox environment is available.
@@ -105,6 +113,7 @@ Integration tests live under `tests/integration/targets/<target_name>/`.
 
 When tests fail, classify first and then act:
 
+- **Ruff/formatting failures**: run `nox -Re formatters`, then optionally `nox -Re codeqa` to verify, and retry tests.
 - **Collection import/path failures**: verify working directory and collection path (`ansible_collections/community/proxmox/` on `ANSIBLE_COLLECTIONS_PATHS`).
 - **Container runtime issues (`--docker`)**: verify Docker/Podman availability; rerun with the same command after fixing runtime access.
 - **Unsupported integration target**: use `--allow-unsupported`; still requires real Proxmox environment and valid `tests/integration/integration_config.yml`.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -96,7 +96,7 @@ Integration tests live under `tests/integration/targets/<target_name>/`.
 
 ## Test Expectations
 
-- Documentation-only changes: no tests required.
+- Documentation-only changes: run sanity tests.
 - Code changes: run sanity and targeted unit tests at minimum.
 - Behavior changes in modules: also run targeted integration tests when a Proxmox environment is available.
 - New modules and bug fixes: add tests that cover the changed behavior.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 ---
 name: run-tests
 description: Runs and writes tests (sanity, unit, integration) for the community.proxmox Ansible collection using ansible-test. Use when asked to run, check, or write tests for a module or utility. Do not use for PR reviews or questions unrelated to testing.

--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: run-tests
+description: Runs and writes tests (sanity, unit, integration) for the community.proxmox Ansible collection using ansible-test. Use when asked to run, check, or write tests for a module or utility. Do not use for PR reviews or questions unrelated to testing.
+---
+
+# Skill: run-tests
+
+## Purpose
+
+Run and write tests for the `community.proxmox` Ansible collection. Covers sanity, unit, and integration tests using `ansible-test`.
+
+## Quick Start (Smallest Useful Run First)
+
+Use this order unless the user requests otherwise:
+
+1. Run sanity or targeted unit tests for changed files first.
+2. Expand to broader unit coverage only if needed.
+3. Run integration tests only when behavior changed and a Proxmox environment is configured.
+
+## When to Invoke
+
+TRIGGER when:
+
+- A user asks to run tests, check tests, or verify changes with tests
+- A user asks how to test a module or utility
+- A user asks to write tests for new or modified code
+
+DO NOT TRIGGER when:
+
+- Reviewing a PR for overall quality
+- The question is about module logic unrelated to testing
+
+## Test Infrastructure
+
+The collection must be installed at `ansible_collections/community/proxmox/` (relative to a directory on `ANSIBLE_COLLECTIONS_PATHS`) for imports to resolve correctly.
+
+Use `nox` first because CI is built on antsibull-nox sessions. Direct `ansible-test` commands are useful for targeted local runs.
+
+Most Proxmox integration targets are marked `unsupported` and require a real Proxmox environment configured in `tests/integration/integration_config.yml`. Docker/Podman wraps `ansible-test` execution, but it does not provide a Proxmox environment.
+
+---
+
+## Test Commands
+
+### Preferred (CI-aligned): nox
+
+```bash
+# sanity
+nox -Re ansible-test-sanity-devel
+
+# unit (all)
+nox -Re ansible-test-units-devel
+
+# unit (single Python version, faster)
+nox -Re ansible-test-units-devel -- --python 3.13
+
+# targeted unit file
+nox -Re ansible-test-units-devel -- --python 3.13 tests/unit/plugins/modules/test_proxmox_user.py
+```
+
+### Sanity
+
+Checks style, documentation, and imports for a changed file:
+
+```bash
+ansible-test sanity plugins/modules/proxmox_user.py --docker -vvv
+```
+
+### Unit
+
+Runs unit tests for changed files:
+
+```bash
+ansible-test units tests/unit/plugins/modules/test_proxmox_user.py --docker -vvv
+```
+
+Unit tests live under `tests/unit/plugins/` and use the `pytest` framework.
+
+### Integration
+
+Runs integration tests against a configured Proxmox environment (started by Docker):
+
+```bash
+ansible-test integration proxmox_pool --docker -v --allow-unsupported
+```
+
+Integration tests live under `tests/integration/targets/<target_name>/`.
+
+---
+
+## Test Expectations
+
+- Documentation-only changes: no tests required.
+- Code changes: run sanity and targeted unit tests at minimum.
+- Behavior changes in modules: also run targeted integration tests when a Proxmox environment is available.
+- New modules and bug fixes: add tests that cover the changed behavior.
+
+## Failure Triage
+
+When tests fail, classify first and then act:
+
+- **Collection import/path failures**: verify working directory and collection path (`ansible_collections/community/proxmox/` on `ANSIBLE_COLLECTIONS_PATHS`).
+- **Container runtime issues (`--docker`)**: verify Docker/Podman availability; rerun with the same command after fixing runtime access.
+- **Unsupported integration target**: use `--allow-unsupported`; still requires real Proxmox environment and valid `tests/integration/integration_config.yml`.
+- **Missing dependencies/environment**: report exact missing tool/config and provide the minimal command to retry.
+- **Likely flaky/transient failure**: rerun once, then report both outcomes.
+
+If failure root cause is unclear, return the first failing test and full error context instead of guessing.
+
+---
+
+## Integration Test Pattern
+
+For state-changing modules, integration targets should usually follow this sequence:
+
+1. Call the module under test → `register: result`
+2. Assert on `result` using `ansible.builtin.assert`
+3. Verify the resulting state independently → `register: result` → `ansible.builtin.assert`
+4. Add `check_mode: true` coverage for operations that support check mode
+
+```yaml
+- name: Create pool in check mode
+  check_mode: true
+  community.proxmox.proxmox_pool:
+    poolid: test-pool
+  register: result
+
+- name: Assert changed
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result is success
+
+- name: Create pool in real mode
+  community.proxmox.proxmox_pool:
+    poolid: test-pool
+  register: result
+
+- name: Assert changed
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result is success
+      - result.poolid == "{{ poolid }}"
+```
+
+Tests must also cover:
+
+- **Idempotency**: run the same task a second time and assert `result is not changed`.
+- **`state: absent`**: where applicable, remove the resource and assert it is gone.
+- **Failure paths**: where applicable, assert expected failures and messages.
+
+## Reporting Template
+
+When returning test results, include:
+
+- Commands executed
+- Scope (targeted file/target vs full suite)
+- Result summary (pass/fail)
+- First failing test (if any) and likely cause
+- Next recommended step
+
+## Python Version Policy
+
+- Use a single recent Python version (`--python 3.13`) for fast local validation unless broader coverage is requested.
+- When validating CI parity or release readiness, run the full configured matrix/session.

--- a/.agents/subagents/docs-explorer.md
+++ b/.agents/subagents/docs-explorer.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Subagent: docs-explorer
 
 ## Purpose

--- a/.agents/subagents/docs-explorer.md
+++ b/.agents/subagents/docs-explorer.md
@@ -1,0 +1,44 @@
+# Subagent: docs-explorer
+
+## Purpose
+
+Look up documentation for any library, framework, tool, or technology. Use this subagent whenever a task requires finding correct API usage, configuration options, method signatures, or behavior of an external dependency.
+
+## When to Invoke
+
+Delegate to this subagent when:
+
+- A task requires knowledge of a specific library's API or configuration format
+- Correct syntax or available options for a tool or framework need to be verified
+- Behavior of an external dependency is unclear from reading the code alone
+- A parameter, function, or feature needs to be checked against official documentation
+
+Do not invoke when:
+
+- The answer is already present in the codebase or in context
+- The question is about project-specific logic, not an external dependency
+
+## Approach
+
+1. **Identify the subject**: Extract the library or tool name and the specific question (e.g., function name, config key, module behavior).
+2. **Use specialized tools first**: If you have access to a dedicated documentation tool (e.g., a docs MCP server, retrieval plugin, or similar), prefer it over generic web search.
+3. **Parallelize when possible**: Execute independent lookups in parallel. Use sequential follow-up lookups when later queries depend on earlier results.
+4. **Prefer machine-readable formats**: When multiple formats are available, follow this fallback order:
+   - `llms.txt` (purpose-built for LLM consumption)
+   - `.md` or `.rst` files (structured, low-noise)
+   - Official HTML documentation pages
+   - Forums, blog posts, or other secondary sources
+5. **Extract the relevant information**: Read the source and pull out only what is needed to answer the question — do not summarize the entire page.
+6. **Apply source trust policy**: Prefer official vendor docs and API references. Use community/forum content only as secondary context and label it as such.
+7. **Handle uncertainty explicitly**: If documentation is missing, conflicting, or version-ambiguous, say "not confirmed", list what was checked, and do not guess.
+8. **Return a concise answer**: Provide the relevant API details, examples, or configuration values with a source reference (URL or doc title).
+
+## Output Format
+
+Return:
+
+- A direct answer to the documentation question
+- A minimal code example or config snippet if applicable
+- The source (doc page title or URL)
+
+Keep the response focused. Do not include unrelated sections of documentation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+This file is intended for AI coding agents. It is kept human-readable so contributors can also use it as a quick-reference guide.
+
+When official documentation is not explicitly provided or it's insufficient, you MUST delegate to the `docs-explorer` subagent (see `.agents/subagents/docs-explorer.md`) to look up current official documentation for the relevant libraries and technologies.
+
+## What This Project Is
+
+An Ansible collection (`community.proxmox`) providing modules for managing [Proxmox VE](https://www.proxmox.com) — a virtualization management platform. No roles exist — only modules and shared utilities.
+
+## Development Environment
+
+The collection must reside at `ansible_collections/community/proxmox/` (relative to a directory on `ANSIBLE_COLLECTIONS_PATHS`) for imports to resolve correctly.
+
+For test commands, patterns, and requirements see `.agents/skills/run-tests/SKILL.md`.
+
+## Agent Operating Procedure
+
+Classify the request before acting:
+
+1. `code_change`: implement requested behavior in the smallest safe scope
+2. `testing`: run or add tests using `.agents/skills/run-tests/SKILL.md`
+3. `docs_lookup`: verify external API/framework behavior with the docs-explorer subagent
+4. `review_or_question`: analyze existing code and return findings/answers without unrelated edits
+
+Execution policy:
+
+- Run safe local checks and targeted tests proactively for changed code.
+- Ask before long-running, destructive, or environment-dependent operations when intent is unclear.
+- Never mix unrelated refactors with the requested task.
+
+## Preferred Documentation Sources
+
+Use official and canonical documentation first. Prefer sources in this order:
+
+1. Official project documentation and API references
+2. Official collection/community contributor documentation
+3. Secondary sources (blog posts, forums, Q&A) only for extra context
+
+Preferred sources:
+
+- Ansible developer guide: <https://docs.ansible.com/ansible/latest/dev_guide/>
+- Ansible collection contributor docs: <https://docs.ansible.com/projects/ansible/latest/community/contributions_collections.html>
+- Ansible developing modules docs: <https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_modules_general.html>
+- Ansible module documentation format and conventions (use for module docstrings and `DOCUMENTATION`/`EXAMPLES`/`RETURN`): <https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_modules_documenting.html#developing-modules-documenting>
+- Ansible module `argument_spec` and option constraints (use for `module_args()`, `module_options()`, and `create_proxmox_module()`): <https://docs.ansible.com/projects/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec>
+- Proxmox VE API viewer: <https://pve.proxmox.com/pve-docs/api-viewer/index.html>
+- Proxmox VE documentation: <https://pve.proxmox.com/pve-docs/>
+- Proxmox wiki: <https://pve.proxmox.com/wiki/Main_Page>
+
+## Coding Guidelines
+
+- Follow these software development principles: KISS (Keep It Simple, Stupid), DRY (Don't Repeat Yourself), YAGNI (You Aren't Gonna Need It), Separation of Concerns, Composition over Inheritance, and Convention Over Configuration.
+- Prioritize code simplicity and readability over flexibility.
+- Favor simple, short, and easily testable functions with no side effects over classes. Use classes only when they naturally fit the problem and help avoid boilerplate code while grouping tightly related functionality.
+- Use `snake_case` for all variable and parameter names.
+- Shared code used by multiple modules belongs in `plugins/module_utils/` (DRY principle). Do not duplicate connection or utility logic in individual modules.
+- Do not add connection parameters to individual modules. Extend the `proxmox` doc fragment in `plugins/doc_fragments/proxmox.py` instead.
+- All code changes must pass sanity and unit tests. Run integration tests for behavior changes in a configured Proxmox environment.
+- Keep each piece of work focused on solving a single, specific issue or task. Do not mix unrelated changes (e.g., a bugfix and an unrelated refactoring) in the same branch or PR.
+- Use conventional commit message prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`. Add a scope with the module name when applicable (e.g. `proxmox_pool`, `proxmox_storage`). Example: `fix(proxmox_pool): handle nested pool`.
+
+## Development Conventions
+
+- Every PR that changes module behavior needs a changelog fragment in `changelogs/fragments/<something>.yaml`. Docs/tests/refactoring PRs are exempt and also new modules. Valid fragment sections: `major_changes`, `minor_changes`, `bugfixes`, `breaking_changes`, `deprecated_features`, `removed_features`, `security_fixes`, `known_issues`, `trivial`. Fragments are consumed (deleted) at release time (`keep_fragments: false` in `changelogs/config.yaml`).
+
+## Definition of Done
+
+Before finalizing work, verify:
+
+- Requested behavior is implemented in the intended scope only.
+- Relevant sanity/unit tests are run (and integration tests for behavior changes when environment is available), or a clear reason is provided if not run.
+- Changed files are free of newly introduced lint/sanity issues.
+- Changelog fragment requirement is evaluated for behavior changes.
+- Response includes key outcomes, risks, and any follow-up actions needed.
+
+## Subagents
+
+Subagent definitions live in `.agents/subagents/`. When a task matches a subagent's trigger conditions, delegate to it.
+
+## Agent Skills
+
+Skills live in `.agents/skills/*/SKILL.md`. At session start, scan and register all skills. When a request matches a skill's trigger, load and apply it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Preferred sources:
 - Favor simple, short, and easily testable functions with no side effects over classes. Use classes only when they naturally fit the problem and help avoid boilerplate code while grouping tightly related functionality.
 - Use `snake_case` for all variable and parameter names.
 - Shared code used by multiple modules belongs in `plugins/module_utils/` (DRY principle). Do not duplicate connection or utility logic in individual modules.
-- Do not add connection parameters to individual modules. Extend the `proxmox` doc fragment in `plugins/doc_fragments/proxmox.py` instead.
+- Do not add connection parameters to individual modules. Extend the `proxmox` doc fragment in `plugins/doc_fragments/proxmox.py` and `plugins/module_utils/proxmox.py` instead.
 - All code changes must pass sanity and unit tests. Run integration tests for behavior changes in a configured Proxmox environment.
 - Keep each piece of work focused on solving a single, specific issue or task. Do not mix unrelated changes (e.g., a bugfix and an unrelated refactoring) in the same branch or PR.
 - Use conventional commit message prefixes: `feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`, `ci:`. Add a scope with the module name when applicable (e.g. `proxmox_pool`, `proxmox_storage`). Example: `fix(proxmox_pool): handle nested pool`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Before finalizing work, verify:
 
 - Requested behavior is implemented in the intended scope only.
 - Relevant sanity/unit tests are run (and integration tests for behavior changes when environment is available), or a clear reason is provided if not run.
-- Changed files are free of newly introduced lint/sanity issues.
+- Changed files are free of newly introduced lint/sanity issues (run `nox -Re formatters` for Python changes; see `.agents/skills/run-tests/SKILL.md`).
 - Changelog fragment requirement is evaluated for behavior changes.
 - Response includes key outcomes, risks, and any follow-up actions needed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # AGENTS.md
 
 This file is intended for AI coding agents. It is kept human-readable so contributors can also use it as a quick-reference guide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Preferred sources:
 ## Development Conventions
 
 - Every PR that changes module behavior needs a changelog fragment in `changelogs/fragments/<something>.yaml`. Docs/tests/refactoring PRs are exempt and also new modules. Valid fragment sections: `major_changes`, `minor_changes`, `bugfixes`, `breaking_changes`, `deprecated_features`, `removed_features`, `security_fixes`, `known_issues`, `trivial`. Fragments are consumed (deleted) at release time (`keep_fragments: false` in `changelogs/config.yaml`).
+- All PRs made with AI support must be annotated as such in the PR text and/or the AI agent must be a co-author on the commts
 
 ## Definition of Done
 


### PR DESCRIPTION
##### SUMMARY

Add guidances for AI coding agents.

Each file has been inspired/copy/adjusted from various other community collections (e.g vmware, rabbitmq, postgresql, ..).

##### ISSUE TYPE

- Docs Pull Request