### PR TITLE
fix(proxmox_user): ignore password update with api token auth

### DIFF
--- a/changelogs/fragments/451-proxmox-user-handle-password-with-api-token-auth.yml
+++ b/changelogs/fragments/451-proxmox-user-handle-password-with-api-token-auth.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_user - ignore ``password`` parameter when updating an existing user using API Token authentication (https://github.com/ansible-collections/community.proxmox/issues/451).

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -310,7 +310,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
                 )
         return result_tokens
 
-    def create_update_user(  # noqa: PLR0913
+    def create_update_user(  # noqa: PLR0913 PLR0912
         self,
         userid,
         comment=None,
@@ -385,9 +385,17 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
                         changed=False, userid=userid, msg=f"Failed to update user with ID {userid}: {e}"
                     )
 
+            # The password cannot be updated when using API Token authentication
+            is_api_token_auth = self.module.params["api_token_id"] is not None
+            if password and is_api_token_auth:
+                self.module.warn(
+                    "Password cannot be updated when using API Token authentication. Ignoring password parameter.",
+                )
+                self.module.exit_json(changed=False, userid=userid, msg=f"User {userid} already up to date")
+
             # We have no way of testing if the user's password needs to be changed
             # so, if it's provided we will update it anyway
-            if password:
+            if password and not is_api_token_auth:
                 try:
                     self.proxmox_api.access.password.put(userid=userid, password=password)
                     self.module.exit_json(changed=True, userid=userid, msg=f"User {userid} updated")

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -386,8 +386,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
                     )
 
             # The password cannot be updated when using API Token authentication
-            is_api_token_auth = self.module.params["api_token_id"] is not None
-            if password and is_api_token_auth:
+            if password and self.module.params["api_token_id"]:
                 self.module.warn(
                     "Password cannot be updated when using API Token authentication. Ignoring password parameter.",
                 )

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -394,7 +394,7 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
 
             # We have no way of testing if the user's password needs to be changed
             # so, if it's provided we will update it anyway
-            if password and not is_api_token_auth:
+            if password and self.module.params["api_token_id"]:
                 try:
                     self.proxmox_api.access.password.put(userid=userid, password=password)
                     self.module.exit_json(changed=True, userid=userid, msg=f"User {userid} updated")


### PR DESCRIPTION
##### SUMMARY

When `proxmox_user` updates an existing user and the authentication method is API token, skip the password change.

Proxmox does not support it (permission issue) over that auth method, the module now warns and ignores password instead of failing.

Fixes #442
Replace #445

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_user`