### PR TITLE
Remove trailing whitespace from workflow

### DIFF
--- a/.github/workflows/changelog-format.yml
+++ b/.github/workflows/changelog-format.yml
@@ -82,7 +82,6 @@ jobs:
                         ]:
                             print(f"unrecognized change type: {typ}")
                             sysexit(1)
-    
                         regex = compile(r".+ - [a-z].*\.")
                         for change in changes:
                             if not regex.fullmatch(change):


### PR DESCRIPTION
Fixes the failing ci due to a trailing whitespace in .github/workflows/changelog.yaml