### PR TITLE
fix(proxmox_node_info): skip version and network when node offline

### DIFF
--- a/changelogs/fragments/453-proxmox_node_info-handle-offline-node.yml
+++ b/changelogs/fragments/453-proxmox_node_info-handle-offline-node.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_node_info - skip node ``network`` and ``version`` info when node is offline to prevent errors (https://github.com/ansible-collections/community.proxmox/issues/453).

--- a/plugins/modules/proxmox_node_info.py
+++ b/plugins/modules/proxmox_node_info.py
@@ -67,7 +67,7 @@ proxmox_nodes:
       type: int
     network:
       description: Active network interfaces on the node
-      returned: on success
+      returned: on success and when node online
       type: dict
     node:
       description: Short hostname of this node.
@@ -91,7 +91,7 @@ proxmox_nodes:
       type: int
     version:
       description: Version of PVE on the node
-      returned: on success
+      returned: on success and when node online
       type: dict
 """
 
@@ -114,6 +114,8 @@ class ProxmoxNodeInfoAnsible(ProxmoxAnsible):
     def get_nodes(self):
         nodes = self.proxmox_api.nodes.get()
         for node in nodes:
+            if node["status"] == "offline":
+                continue
             node_name = node["node"]
             ifaces = self.proxmox_api.nodes(node_name).network.get()
             node["network"] = ifaces


### PR DESCRIPTION
##### SUMMARY

When using `proxmox_node_info` in a cluster and when one node is offline Proxmox can't fetch the node network and version information.

The API return an 595 error on `/api2/json/nodes/offline-node/network` and `/api2/json/nodes/offline-node/version`

Fixes #379

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`proxmox_node_info`
