### PR TITLE
changing documentation of the filter plugin and assing unit tests

### DIFF
--- a/plugins/filter/proxmox2dict.py
+++ b/plugins/filter/proxmox2dict.py
@@ -1,0 +1,361 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import re
+from ansible.errors import AnsibleFilterError
+
+
+# ------------------------------------------------------------
+# DOCUMENTATION (ANSIBLE BEST PRACTICE)
+# ------------------------------------------------------------
+
+DOCUMENTATION = r'''
+---
+name: proxmox2dict
+short_description: Transform Proxmox VM info into structured canonical schema
+version_added: "1.0.0"
+description:
+  - Converts raw Proxmox VM info into a structured dictionary.
+  - Produces canonical schema: parsed.network, parsed.storage, parsed.metadata
+options:
+  convert_types:
+    description:
+      - Convert numeric strings to integers where safe.
+    type: bool
+    default: true
+  build_netconfig:
+    description:
+      - Build extended network structures (dict/list variants).
+    type: bool
+    default: true
+'''
+
+EXAMPLES = r"""
+- name: Get a VM configuration by name
+  community.proxmox.proxmox_vm_config:
+    type: qemu
+    name: generic-vm
+    config: current
+  register: vm_infos
+
+# Example input
+#
+# vm_infos:
+#   proxmox_vms: [
+#  {
+#   "agent": "1",
+#   "memory": "2048",
+#   "name": "generic-vm",
+#   "ipconfig0": "ip=10.0.1.10/24,gw=10.0.1.1",
+#   "net0": "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100,firewall=0",
+#   "net1": "virtio=AA:BB:CC:DD:EE:02,bridge=vmbr200,firewall=0",
+#   "scsi0": "STORAGE_POOL:vm-100-disk-0.qcow2,size=40G",
+#   "tags": "managed;linux;example",
+#   "meta": "creation-qemu=10.0.0,ctime=1700000000"
+# }
+#]
+- name: Transform raw Proxmox VM data into a structured dictionary
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        vm_infos.proxmox_vms
+        | first
+        | community.proxmox.proxmox2dict
+      }}
+
+
+# Example output
+#
+# {
+#   "parsed": {
+#     "metadata": {
+#       "agent": 1,
+#       "memory": 2048,
+#       "name": "generic-vm",
+#       "tags": [
+#         "managed",
+#         "linux",
+#         "example"
+#       ],
+#       "meta": {
+#         "creation-qemu": "10.0.0",
+#         "ctime": "1700000000"
+#       }
+#     },
+#     "network": {
+#       "net_dict": {
+#         "net0": {
+#           "bridge": "vmbr100",
+#           "firewall": "0",
+#           "type": "virtio",
+#           "mac": "AA:BB:CC:DD:EE:01"
+#         },
+#         "net1": {
+#           "bridge": "vmbr200",
+#           "firewall": "0",
+#           "type": "virtio",
+#           "mac": "AA:BB:CC:DD:EE:02"
+#         }
+#       },
+#       "net_dict_macless": {
+#         "net0": {
+#           "bridge": "vmbr100",
+#           "firewall": "0",
+#           "type": "virtio"
+#         },
+#         "net1": {
+#           "bridge": "vmbr200",
+#           "firewall": "0",
+#           "type": "virtio"
+#         }
+#       }
+#     },
+#     "storage": {
+#       "disks": {
+#         "scsi0": {
+#           "storage": "STORAGE_POOL",
+#           "volume": "vm-100-disk-0.qcow2",
+#           "size": "40G"
+#         }
+#       }
+#     }
+#   }
+# }
+"""
+RETURN = r"""
+_value:
+  description: a dict with disk and network information as a dict 
+  type: dict
+"""
+
+# ------------------------------------------------------------
+# GLOBAL CONFIG
+# ------------------------------------------------------------
+
+_IGNORE_KEYS = {
+    "scsihw"
+}
+
+_NET_TYPES = {
+    "virtio", "e1000", "vmxnet3", "rtl8139", "ne2k_pci", "pcnet"
+}
+
+_DISK_PREFIXES = (
+    "scsi",
+    "sata",
+    "ide",
+    "virtio",
+    "efidisk",
+    "tpmstate",
+    "unused",
+    "mp"
+)
+
+
+# ------------------------------------------------------------
+# REQUIRED VALIDATION (INTEGRATED SNIPPET)
+# ------------------------------------------------------------
+
+def _require_dict(value, name="input"):
+    if not isinstance(value, dict):
+        raise AnsibleFilterError(
+            f"proxmox2dict: {name} must be a dict, got {type(value).__name__}"
+        )
+
+
+# ------------------------------------------------------------
+# HELPERS
+# ------------------------------------------------------------
+
+def _convert_scalar(value):
+    if isinstance(value, str) and re.fullmatch(r"\d+", value):
+        return int(value)
+    return value
+
+
+def _parse_kv_string(value):
+    if not isinstance(value, str):
+        raise AnsibleFilterError(
+            f"Expected string for kv parsing, got {type(value).__name__}"
+        )
+
+    out = {}
+    for part in value.split(","):
+        if "=" in part:
+            k, v = part.split("=", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+def _split_tags(value):
+    if isinstance(value, str):
+        return [t.strip() for t in value.split(";") if t.strip()]
+    return value
+
+
+# ------------------------------------------------------------
+# NETWORK PARSER
+# ------------------------------------------------------------
+
+def _parse_network(vm):
+    net_dict = {}
+    net_list = []
+
+    net_dict_macless = {}
+    net_list_macless = []
+
+    for k, v in vm.items():
+
+        if k in _IGNORE_KEYS:
+            continue
+
+        if not re.match(r"^net\d+$", k):
+            continue
+
+        if not isinstance(v, str):
+            raise AnsibleFilterError(
+                f"Network field {k} must be string"
+            )
+
+        parsed = _parse_kv_string(v)
+
+        net_type = None
+        mac = None
+
+        # detect interface type + mac
+        for t in _NET_TYPES:
+            if t in parsed:
+                net_type = t
+                mac = parsed.pop(t)
+                break
+
+        # -----------------------------
+        # FULL VERSION (WITH MAC)
+        # -----------------------------
+        net_obj = dict(parsed)
+
+        if net_type:
+            net_obj["type"] = net_type
+        if mac:
+            net_obj["mac"] = mac
+
+        net_dict[k] = net_obj
+        net_list.append({k: net_obj})
+
+        # -----------------------------
+        # MACLESS VERSION (NEW)
+        # -----------------------------
+        net_obj_macless = dict(parsed)
+
+        if net_type:
+            net_obj_macless["type"] = net_type
+
+        net_dict_macless[k] = net_obj_macless
+        net_list_macless.append({k: net_obj_macless})
+
+    return {
+        "net_dict": net_dict,
+        "net_list": net_list,
+        "net_dict_macless": net_dict_macless,
+        "net_list_macless": net_list_macless
+    }
+# ------------------------------------------------------------
+# STORAGE PARSER
+# ------------------------------------------------------------
+
+def _parse_storage(vm):
+    disks = {}
+
+    for k, v in vm.items():
+
+        if k in _IGNORE_KEYS:
+            continue
+
+        if not any(k.startswith(prefix) for prefix in _DISK_PREFIXES):
+            continue
+
+        if not isinstance(v, str):
+            raise AnsibleFilterError(
+                f"Storage field {k} must be string"
+            )
+
+        storage = None
+        volume = None
+        size = None
+
+        parts = v.split(",")
+
+        if ":" in parts[0]:
+            storage, volume = parts[0].split(":", 1)
+        else:
+            volume = parts[0]
+
+        for p in parts[1:]:
+            if "=" in p:
+                pk, pv = p.split("=", 1)
+                if pk == "size":
+                    size = pv
+
+        disks[k] = {
+            "storage": storage,
+            "volume": volume,
+            "size": size
+        }
+
+    return {"disks": disks}
+
+
+# ------------------------------------------------------------
+# METADATA PARSER
+# ------------------------------------------------------------
+
+def _parse_metadata(vm):
+    meta = {}
+
+    for k, v in vm.items():
+
+        if k in _IGNORE_KEYS:
+            continue
+
+        if k == "meta":
+            meta[k] = _parse_kv_string(v)
+
+        elif k == "tags":
+            meta[k] = _split_tags(v)
+
+        else:
+            meta[k] = _convert_scalar(v)
+
+    return meta
+
+
+# ------------------------------------------------------------
+# MAIN FILTER
+# ------------------------------------------------------------
+
+def proxmox2dict(vm_info, convert_types=True, build_netconfig=True):
+
+    _require_dict(vm_info, "vm_info")
+
+    vm = dict(vm_info)
+
+    parsed = {
+        "metadata": _parse_metadata(vm),
+        "storage": _parse_storage(vm),
+        "network": _parse_network(vm) if build_netconfig else {}
+    }
+
+    return {"parsed": parsed}
+
+
+# ------------------------------------------------------------
+# ANSIBLE ENTRYPOINT
+# ------------------------------------------------------------
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            "proxmox2dict": proxmox2dict
+        }

--- a/tests/unit/plugins/filter/test_proxmox2dict.py
+++ b/tests/unit/plugins/filter/test_proxmox2dict.py
@@ -6,7 +6,7 @@ import pytest
 
 from ansible.errors import AnsibleFilterError
 
-from ansible_collections.example.proxmox.plugins.filter.proxmox2dict import (
+from ansible_collections.community.proxmox.plugins.filter.proxmox2dict import (
     proxmox2dict,
 )
 

--- a/tests/unit/plugins/filter/test_proxmox2dict.py
+++ b/tests/unit/plugins/filter/test_proxmox2dict.py
@@ -1,0 +1,216 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.example.proxmox.plugins.filter.proxmox2dict import (
+    proxmox2dict,
+)
+
+
+def test_basic_vm():
+
+    vm = {
+        "agent": "1",
+        "memory": "2048",
+        "name": "generic-vm",
+        "meta": "creation-qemu=10.0.0,ctime=1700000000",
+        "tags": "managed;linux;example",
+        "net0": "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100,firewall=0",
+        "scsi0": "STORAGE_POOL:vm-100-disk-0.qcow2,size=40G",
+        "scsihw": "virtio-scsi-pci",
+    }
+
+    result = proxmox2dict(vm)
+
+    assert result["parsed"]["metadata"]["agent"] == 1
+    assert result["parsed"]["metadata"]["memory"] == 2048
+
+    assert result["parsed"]["metadata"]["tags"] == [
+        "managed",
+        "linux",
+        "example",
+    ]
+
+    assert result["parsed"]["storage"]["disks"]["scsi0"]["storage"] == "STORAGE_POOL"
+
+    assert (
+        result["parsed"]["storage"]["disks"]["scsi0"]["volume"]
+        == "vm-100-disk-0.qcow2"
+    )
+
+    assert (
+        result["parsed"]["storage"]["disks"]["scsi0"]["size"]
+        == "40G"
+    )
+
+
+def test_network_parsing():
+
+    vm = {
+        "net0": "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100,firewall=0",
+        "net1": "e1000=AA:BB:CC:DD:EE:02,bridge=vmbr200",
+    }
+
+    result = proxmox2dict(vm)
+
+    net0 = result["parsed"]["network"]["net_dict"]["net0"]
+
+    assert net0["type"] == "virtio"
+    assert net0["mac"] == "AA:BB:CC:DD:EE:01"
+    assert net0["bridge"] == "vmbr100"
+
+    net1 = result["parsed"]["network"]["net_dict"]["net1"]
+
+    assert net1["type"] == "e1000"
+    assert net1["mac"] == "AA:BB:CC:DD:EE:02"
+
+
+def test_network_macless_views():
+
+    vm = {
+        "net0": "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100,firewall=0"
+    }
+
+    result = proxmox2dict(vm)
+
+    net = result["parsed"]["network"]["net_dict_macless"]["net0"]
+
+    assert "mac" not in net
+    assert net["type"] == "virtio"
+    assert net["bridge"] == "vmbr100"
+
+    net_list = result["parsed"]["network"]["net_list_macless"]
+
+    assert len(net_list) == 1
+    assert "mac" not in net_list[0]["net0"]
+
+
+def test_multiple_disks():
+
+    vm = {
+        "scsi0": "FAST_STORAGE:vm-100-disk-0,size=40G",
+        "scsi1": "FAST_STORAGE:vm-100-disk-1,size=80G",
+        "sata0": "BACKUP_STORAGE:vm-100-backup,size=500G",
+    }
+
+    result = proxmox2dict(vm)
+
+    disks = result["parsed"]["storage"]["disks"]
+
+    assert len(disks) == 3
+
+    assert disks["scsi0"]["size"] == "40G"
+    assert disks["scsi1"]["size"] == "80G"
+    assert disks["sata0"]["size"] == "500G"
+
+
+def test_meta_parsing():
+
+    vm = {
+        "meta": "creation-qemu=10.0.0,ctime=1700000000"
+    }
+
+    result = proxmox2dict(vm)
+
+    meta = result["parsed"]["metadata"]["meta"]
+
+    assert meta["creation-qemu"] == "10.0.0"
+    assert meta["ctime"] == "1700000000"
+
+
+def test_empty_tags():
+
+    vm = {
+        "tags": ""
+    }
+
+    result = proxmox2dict(vm)
+
+    assert result["parsed"]["metadata"]["tags"] == []
+
+
+def test_ignore_scsihw():
+
+    vm = {
+        "scsihw": "virtio-scsi-pci",
+        "scsi0": "LOCAL:disk,size=10G",
+    }
+
+    result = proxmox2dict(vm)
+
+    assert "scsihw" not in result["parsed"]["metadata"]
+
+    assert (
+        result["parsed"]["storage"]["disks"]["scsi0"]["size"]
+        == "10G"
+    )
+
+
+def test_build_netconfig_false():
+
+    vm = {
+        "net0": "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100"
+    }
+
+    result = proxmox2dict(
+        vm,
+        build_netconfig=False,
+    )
+
+    assert result["parsed"]["network"] == {}
+
+
+def test_invalid_input_list():
+
+    with pytest.raises(AnsibleFilterError):
+        proxmox2dict(["a", "b", "c"])
+
+
+def test_invalid_input_string():
+
+    with pytest.raises(AnsibleFilterError):
+        proxmox2dict("not-a-dict")
+
+
+def test_invalid_network_type():
+
+    vm = {
+        "net0": 12345
+    }
+
+    with pytest.raises(AnsibleFilterError):
+        proxmox2dict(vm)
+
+
+def test_invalid_storage_type():
+
+    vm = {
+        "scsi0": 12345
+    }
+
+    with pytest.raises(AnsibleFilterError):
+        proxmox2dict(vm)
+
+
+def test_empty_dict():
+
+    result = proxmox2dict({})
+
+    assert result == {
+        "parsed": {
+            "metadata": {},
+            "storage": {
+                "disks": {}
+            },
+            "network": {
+                "net_dict": {},
+                "net_list": [],
+                "net_dict_macless": {},
+                "net_list_macless": [],
+            },
+        }
+    }


### PR DESCRIPTION
##### SUMMARY

This pull request introduces a new filter plugin named `proxmox2dict` that transforms raw Proxmox VM configuration data into a normalized and structured dictionary.

The primary goal is to simplify the consumption of Proxmox VM information within playbooks, templates, inventory generation workflows, and automation pipelines by providing a predictable schema independent of the original Proxmox string-based representation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

###### Motivation

Proxmox VM configuration data contains several fields that are represented as comma-separated or semicolon-separated strings:

* Network interfaces (`net0`, `net1`, ...)
* IP configurations (`ipconfig0`, `ipconfig1`, ...)
* Storage devices (`scsi0`, `sata0`, `virtio0`, ...)
* Metadata fields (`meta`)
* Tags (`tags`)

Consumers of Proxmox data typically need to repeatedly implement custom parsing logic in playbooks and templates.

This filter centralizes and standardizes that transformation logic.

######  New Filter

```yaml
{{ vm_info | community.proxmox.proxmox2dict }}
```

######  Features

The features that this plugin offers are listed below: 

**Canonical schema**

The filter returns a structured schema:

```yaml
parsed:
  metadata:
  network:
  storage:
```

**Metadata normalization**

* Converts numeric strings to integers
* Converts `meta` fields into dictionaries
* Converts Proxmox tag strings into lists

Example:

```yaml
tags: "managed;linux;production"
```

becomes

```yaml
tags:
  - managed
  - linux
  - production
```

**Network normalization**

Parses all `netX` interfaces into structured objects.

Example:

```yaml
net0: "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr0,firewall=0"
```

becomes

```yaml
net0:
  type: virtio
  mac: AA:BB:CC:DD:EE:01
  bridge: vmbr0
  firewall: "0"
```

The plugin exposes multiple network views:

```yaml
network:
  net_dict:
  net_list:
  net_dict_macless:
  net_list_macless:
```

The macless variants are useful when generating deterministic inventories or comparing VM configurations independently from hardware addresses.

**Storage normalization**

Parses storage devices from:

* `scsiX`
* `sataX`
* `ideX`
* `virtioX`
* `efidiskX`
* `tpmstateX`
* `unusedX`
* `mpX`

Example:

```yaml
scsi0: "LOCAL:vm-100-disk-0,size=40G"
```

becomes

```yaml
storage:
  disks:
    scsi0:
      storage: LOCAL
      volume: vm-100-disk-0
      size: 40G
```

**Error handling**

The filter performs input validation and raises `AnsibleFilterError` when invalid data is supplied.

Example:

```yaml
{{ "invalid" | proxmox2dict }}
```

returns:

```text
proxmox2dict: vm_info must be a dict, got str
```

######  Example

Input:

```yaml
net0: "virtio=AA:BB:CC:DD:EE:01,bridge=vmbr100"
scsi0: "LOCAL:vm-100-disk-0,size=40G"
tags: "managed;linux"
```

Output:

```yaml
parsed:
  metadata:
    tags:
      - managed
      - linux

  network:
    net_dict:
      net0:
        type: virtio
        mac: AA:BB:CC:DD:EE:01
        bridge: vmbr100

  storage:
    disks:
      scsi0:
        storage: LOCAL
        volume: vm-100-disk-0
        size: 40G
```

######   Testing

This contribution includes unit tests using `ansible-test`

######   Benefits

* Eliminates repeated parsing logic in playbooks
* Provides a stable schema for downstream automation
* Simplifies inventory generation
* Simplifies VM comparison and drift detection
* Improves readability and maintainability of Proxmox-based automation


######    Backward Compatibility

This change is additive and introduces a new filter plugin only. No existing functionality is modified.

This format should fit well as a GitHub pull request description for an Ansible collection or a Proxmox-focused community collection.

