### PR TITLE
docs(contributing): add welcoming intro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,11 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Contributing
 
-**First:** if you're unsure or afraid of anything, ask for help! You can submit a work in progress (WIP) pull request, or file an issue with the parts you know. We'll do our best to guide you in the right direction, and let you know if there are guidelines we will need to follow. We want people to be able to participate without fear of doing the wrong thing.
+**First:** if you're unsure or afraid of anything, ask for help! You can submit a work in progress (WIP) pull request, or file an issue with the parts you know.
+We'll do our best to guide you in the right direction, and let you know if there are guidelines we will need to follow. We want people to be able to participate without fear of doing the wrong thing.
 
-Below are our expectations for contributors. Following these guidelines gives us the best opportunity to work with you, by making sure we have the things we need in order to make it happen. Doing your best to follow it will speed up our ability to merge PRs and respond to issues.
+Below are our expectations for contributors. Following these guidelines gives us the best opportunity to work with you, by making sure we have the things we need in order to make it happen.
+Doing your best to follow it will speed up our ability to merge PRs and respond to issues.
 
 We follow [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
 in all our contributions and interactions within this repository. If you are stuck while developing a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 # Contributing
 
+**First:** if you're unsure or afraid of anything, ask for help! You can submit a work in progress (WIP) pull request, or file an issue with the parts you know. We'll do our best to guide you in the right direction, and let you know if there are guidelines we will need to follow. We want people to be able to participate without fear of doing the wrong thing.
+
+Below are our expectations for contributors. Following these guidelines gives us the best opportunity to work with you, by making sure we have the things we need in order to make it happen. Doing your best to follow it will speed up our ability to merge PRs and respond to issues.
+
 We follow [Ansible Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html)
 in all our contributions and interactions within this repository. If you are stuck while developing a
 module, refer to our [recommended reads](#helpful-documentation) from the Ansible docs.


### PR DESCRIPTION
##### SUMMARY

Add a welcoming intro on contributing guide. The testing and AI-contribution rules can feel "intimidating" for first time contributors. This will I hope encourages people to ask for help, open WIP PRs or create an issues when stuck.

##### ISSUE TYPE

- Docs Pull Request
