### PR TITLE
proxmox_qemu_api: Add exception in debug logging

### DIFF
--- a/changelogs/fragments/460-add-exception-in-debug-logging.yml
+++ b/changelogs/fragments/460-add-exception-in-debug-logging.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
- - proxmox_qemu_api - adds extra debug logging (exceptions) when trying to connect to guest agent.
+ - proxmox_qemu_api - adds extra debug logging (exceptions) when trying to connect to guest agent (https://github.com/ansible-collections/community.proxmox/pull/460).

--- a/changelogs/fragments/460-add-exception-in-debug-logging.yml
+++ b/changelogs/fragments/460-add-exception-in-debug-logging.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+ - proxmox_qemu_api - adds extra debug logging (exceptions) when trying to connect to guest agent

--- a/changelogs/fragments/460-add-exception-in-debug-logging.yml
+++ b/changelogs/fragments/460-add-exception-in-debug-logging.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
- - proxmox_qemu_api - adds extra debug logging (exceptions) when trying to connect to guest agent
+ - proxmox_qemu_api - adds extra debug logging (exceptions) when trying to connect to guest agent.

--- a/plugins/connection/proxmox_qemu_api.py
+++ b/plugins/connection/proxmox_qemu_api.py
@@ -294,11 +294,11 @@ class Connection(ConnectionBase):
                 self._connected = True
                 display.vvv(f"QEMU guest agent responsive on VM {self.get_option('vmid')}")
                 return self
-            except Exception:
+            except Exception as e:
                 if attempt < attempts - 1:
                     display.vvv(
                         f"Guest agent not ready on VM {self.get_option('vmid')}, "
-                        f"retrying in {interval}s ({attempt + 1}/{attempts})"
+                        f"retrying in {interval}s ({attempt + 1}/{attempts}): {e}"
                     )
                     time.sleep(interval)
                 else:


### PR DESCRIPTION
This adds the responsible error/exception inside of the debugging output, instead of simply folding all possible errors into "guest agent is not responding".

I've had many debugging hours trying to attempt to figure out what exactly is wrong, turning on debugging to the max, only to figure out that often enough its a *connection to the proxmox host* issue, and not a *guest agent is not responding* issue.

I'd like to have been informed of this issue earlier, but the logging simply threw away the exception and folded it all into a sense/idea of "yeah I can connect to the host, but the guest agent isn't responding".

I only found out after I manually did `qm agent <VMID> ping`, and then manually edited my local files to output errors this way, and found it just errored like so;

```
Guest agent not ready on VM <REDACTED>, retrying in 5s (1/12): HTTPSConnectionPool(host='<REDACTED>', port=8006): Max retries exceeded with url: /api2/json/nodes/<REDACTED>/qemu/<REDACTED>/agent/ping (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f5566a57770>: Failed to establish a new connection: [Errno 111] Verbinding is geweigerd'))
```

### What does this PR do?
Adds basic exception logging to the "Guest agent not ready on VM" debug line.

### Issue Type
- Bugfix Pull Request

### Component Name
`proxmox_qemu_api` connection plugin.

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [ ] I have considered backward compatibility.
- [ ] I haved added a changelog fragment (expect for new a module).

(I'm not sure if any apply, considering I did a simple f-string change)
