### PR TITLE
Pool member allow move

### DIFF
--- a/changelogs/fragments/467-pool-member-allow-mode.yml
+++ b/changelogs/fragments/467-pool-member-allow-mode.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - proxmox_pool_member - add ``allow_move`` parameter to allow adding a guest even if already in another pool (https://github.com/ansible-collections/community.proxmox/pull/467).
+bugfixes:
+  - proxmox_pool_member - fix incorrect type when adding members (https://github.com/ansible-collections/community.proxmox/issues/459).
+  - proxmox_pool_member - fix support adding and removing in one execution in ``exclusive`` mode (https://github.com/ansible-collections/community.proxmox/pull/467).

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -253,26 +253,22 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
         self._fail_on_missing_storage(storages_to_add)
 
         if bool(vms_to_add or storages_to_add):
-            payload = {}
-            if allow_move:
-                payload["allow-move"] = 1
-            if vms_to_add:
-                payload["vms"] = sorted(vms_to_add)
-            if storages_to_add:
-                payload["storage"] = sorted(storages_to_add)
-
+            payload = {
+                "allow-move": int(allow_move),
+                "vms": sorted(vms_to_add),
+                "storage": sorted(storages_to_add)
+            }
             try:
                 self.proxmox_api.pools.put(poolid=poolid, **payload)
             except Exception as e:
                 self.module.fail_json(msg=f"Failed to add pool {poolid} membership: {e}")
 
         if bool(vms_to_remove or storages_to_remove):
-            payload = {"delete": 1}
-            if vms_to_remove:
-                payload["vms"] = sorted(vms_to_remove)
-            if storages_to_remove:
-                payload["storage"] = sorted(storages_to_remove)
-
+            payload = {
+                "allow-move": int(allow_move),
+                "vms": sorted(vms_to_remove),
+                "storage": sorted(storages_to_remove)
+            }
             try:
                 self.proxmox_api.pools.put(poolid=poolid, **payload)
             except Exception as e:

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -58,6 +58,12 @@ options:
       - If you want multiple members in the pool you need to pass them all to `members' in a single batch.
     type: bool
     default: false
+  allow_move:
+    description:
+      - When V(true), allow adding a guest even if already in another pool.
+      - The guest will be removed from its current pool and added to this one.
+    type: bool
+    default: false
 
 extends_documentation_fragment:
   - community.proxmox.proxmox.actiongroup_proxmox
@@ -142,6 +148,7 @@ def module_args():
         ),
         state=dict(default="present", choices=["present", "absent"]),
         exclusive=dict(type="bool", default=False),
+        allow_move=dict(type="bool", default=False),
     )
 
 
@@ -193,7 +200,7 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
                 self.module.fail_json(msg=f"Storage(s) not found in the cluster: {', '.join(sorted(missing))}")
 
     def reconcile_members(
-        self, poolid: str, desired_members: list[dict[str, str]], exclusive: bool, state: str
+        self, poolid: str, desired_members: list[dict[str, str]], exclusive: bool, state: str, allow_move: bool
     ) -> tuple[bool, list[dict[str, str]]]:
         """Compute and apply the delta between current and desired membership.
 
@@ -246,6 +253,8 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
         self._fail_on_missing_storage(storages_to_add)
 
         payload = {}
+        if allow_move:
+            payload["allow-move"] = 1
         if vms_to_add:
             payload["vms"] = sorted(vms_to_add)
         elif vms_to_remove:
@@ -274,8 +283,9 @@ def main():
     members = module.params["members"]
     state = module.params["state"]
     exclusive = module.params["exclusive"]
+    allow_move = module.params["allow_move"]
 
-    changed, final_members = proxmox.reconcile_members(poolid, members, exclusive, state)
+    changed, final_members = proxmox.reconcile_members(poolid, members, exclusive, state, allow_move)
 
     module.exit_json(
         changed=changed,

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -253,22 +253,14 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
         self._fail_on_missing_storage(storages_to_add)
 
         if bool(vms_to_add or storages_to_add):
-            payload = {
-                "allow-move": int(allow_move),
-                "vms": sorted(vms_to_add),
-                "storage": sorted(storages_to_add)
-            }
+            payload = {"allow-move": int(allow_move), "vms": sorted(vms_to_add), "storage": sorted(storages_to_add)}
             try:
                 self.proxmox_api.pools.put(poolid=poolid, **payload)
             except Exception as e:
                 self.module.fail_json(msg=f"Failed to add pool {poolid} membership: {e}")
 
         if bool(vms_to_remove or storages_to_remove):
-            payload = {
-                "allow-move": int(allow_move),
-                "vms": sorted(vms_to_remove),
-                "storage": sorted(storages_to_remove)
-            }
+            payload = {"delete": 1, "vms": sorted(vms_to_remove), "storage": sorted(storages_to_remove)}
             try:
                 self.proxmox_api.pools.put(poolid=poolid, **payload)
             except Exception as e:

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -164,7 +164,7 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
             if member["type"] == "storage":
                 storage.add(member["storage"])
             else:
-                vms.add(member["vmid"])
+                vms.add(str(member["vmid"]))
         return (vms, storage)
 
     def _resolve_member(self, member_spec: dict[str, str]) -> tuple[str, str]:

--- a/plugins/modules/proxmox_pool_member.py
+++ b/plugins/modules/proxmox_pool_member.py
@@ -252,25 +252,31 @@ class ProxmoxPoolMemberAnsible(ProxmoxAnsible):
 
         self._fail_on_missing_storage(storages_to_add)
 
-        payload = {}
-        if allow_move:
-            payload["allow-move"] = 1
-        if vms_to_add:
-            payload["vms"] = sorted(vms_to_add)
-        elif vms_to_remove:
-            payload["vms"] = sorted(vms_to_remove)
-            payload["delete"] = 1
+        if bool(vms_to_add or storages_to_add):
+            payload = {}
+            if allow_move:
+                payload["allow-move"] = 1
+            if vms_to_add:
+                payload["vms"] = sorted(vms_to_add)
+            if storages_to_add:
+                payload["storage"] = sorted(storages_to_add)
 
-        if storages_to_add:
-            payload["storage"] = sorted(storages_to_add)
-        elif storages_to_remove:
-            payload["storage"] = sorted(storages_to_remove)
-            payload["delete"] = 1
+            try:
+                self.proxmox_api.pools.put(poolid=poolid, **payload)
+            except Exception as e:
+                self.module.fail_json(msg=f"Failed to add pool {poolid} membership: {e}")
 
-        try:
-            self.proxmox_api.pools.put(poolid=poolid, **payload)
-        except Exception as e:
-            self.module.fail_json(msg=f"Failed to update pool {poolid} membership: {e}")
+        if bool(vms_to_remove or storages_to_remove):
+            payload = {"delete": 1}
+            if vms_to_remove:
+                payload["vms"] = sorted(vms_to_remove)
+            if storages_to_remove:
+                payload["storage"] = sorted(storages_to_remove)
+
+            try:
+                self.proxmox_api.pools.put(poolid=poolid, **payload)
+            except Exception as e:
+                self.module.fail_json(msg=f"Failed to remove pool {poolid} membership: {e}")
 
         return True, self._pool_members_as_dicts(after_vms, after_storages)
 


### PR DESCRIPTION
### What does this PR do?

 * Add allow_move parameter to allow adding a guest even if already in another pool. The guest will be removed from its current pool and added to this one.
 * Fix: #459 proxmox_pool_member incorrect type when adding members
 * Fix: support adding and removing in one execution.  In `exclusive` mode the module could need to add and remove some vms or storages at the same time. The old code needed two executions to do it.


### Issue Type
- Bugfix Pull Request
- Feature Pull Request

### Component Name
proxmox_pool_member

### Contributor's Note
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [ ] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

Fixes #459
