### PR TITLE
feat(proxmox_nic): increase max queues size in module doc

### DIFF
--- a/changelogs/fragments/468-proxmox_nix-update-queue-limit-doc.yaml
+++ b/changelogs/fragments/468-proxmox_nix-update-queue-limit-doc.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - proxmox_nic - increase max queues to 64 (https://github.com/ansible-collections/community.proxmox/pull/468).

--- a/plugins/modules/proxmox_nic.py
+++ b/plugins/modules/proxmox_nic.py
@@ -62,7 +62,7 @@ options:
   queues:
     description:
       - Number of packet queues to be used on the device.
-      - Value should be C(0 ≤ n ≤ 16).
+      - Value should be C(1 ≤ n ≤ 64).
     type: int
   rate:
     description:


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

On the module `proxmox_nic` the documentation of the parameter `queues` is outdated.

This PR increase max `queues` size to 64 to match latest PVE limit.

### Issue Type
<!--- Pick one below and delete the rest. -->

- Feature Pull Request

### Component Name

`proxmox_nic`

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #465
