### PR TITLE
fix(proxmox_template) cross node upload

### DIFF
--- a/changelogs/fragments/470-fix-proxmox-template-cross-node.yml
+++ b/changelogs/fragments/470-fix-proxmox-template-cross-node.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_template - fix error if ``api_host`` and upload target `node` are not the same (https://github.com/ansible-collections/community.proxmox/issues/222).

--- a/plugins/modules/proxmox_template.py
+++ b/plugins/modules/proxmox_template.py
@@ -213,10 +213,11 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
         except Exception as e:
             self.module.fail_json(msg=f"Failed to retrieve template '{volid}': {e}")
 
-    def task_status(self, node, taskid, timeout):
+    def task_status(self, taskid, timeout):
         """
         Check the task status and wait until the task is completed or the timeout is reached.
         """
+        node = self.upid_to_node(taskid)
         while timeout:
             if self.api_task_ok(node, taskid):
                 return True
@@ -248,7 +249,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
                 .storage(storage)
                 .upload.post(content=content_type, filename=open(realpath, "rb"))  # noqa: SIM115
             )
-            return self.task_status(node, taskid, timeout)
+            return self.task_status(taskid, timeout)
         except Exception as e:
             self.module.fail_json(msg=f"Uploading template {realpath} failed with error: {e}")
 
@@ -260,14 +261,14 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
                 .storage(storage)("download-url")
                 .post(url=url, content=content_type, filename=template)
             )
-            return self.task_status(node, taskid, timeout)
+            return self.task_status(taskid, timeout)
         except Exception as e:
             self.module.fail_json(msg=f"Fetching template from url {url} failed with error: {e}")
 
     def download_template(self, node, storage, template, timeout):
         try:
             taskid = self.proxmox_api.nodes(node).aplinfo.post(storage=storage, template=template)
-            return self.task_status(node, taskid, timeout)
+            return self.task_status(taskid, timeout)
         except Exception as e:
             self.module.fail_json(msg=f"Downloading template {template} failed with error: {e}")
 
@@ -295,7 +296,7 @@ class ProxmoxTemplateAnsible(ProxmoxAnsible):
         }
         try:
             taskid = self.proxmox_api.nodes(node).storage(storage).post(f"download-url?{urlencode(data)}")
-            return self.task_status(node, taskid, timeout)
+            return self.task_status(taskid, timeout)
         except Exception as e:
             self.module.fail_json(msg=f"Checksum mismatch: {e}")
 

--- a/tests/integration/targets/proxmox_template/tasks/main.yml
+++ b/tests/integration/targets/proxmox_template/tasks/main.yml
@@ -42,30 +42,6 @@
           - result is failed
           - result.msg is match('\'requests_toolbelt\' module is required to upload files larger than 256MB')
 
-    - name: Install old (1.1.2) version of proxmoxer
-      ansible.builtin.pip:
-        name: proxmoxer==1.1.1
-        state: present
-
-    - name: Upload ISO as template to Proxmox VE cluster should be successful
-      proxmox_template:
-        node: '{{ node }}'
-        src: '{{ filename }}'
-        content_type: iso
-        force: true
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-          - result is success
-          - result.msg is match('template with volid=local:iso/dummy.iso uploaded')
-
-    - name: Install latest proxmoxer
-      ansible.builtin.pip:
-        name: proxmoxer
-        state: latest
-
     - name: Make smaller dummy file
       ansible.builtin.command:
         cmd: 'truncate -s 128M {{ filename }}'


### PR DESCRIPTION
### What does this PR do?

If connected to a different api node the the one the upload is for the upload fails. As the task is created on the node the api is connected to, but the task is checks on the one the upload is for. By using the node from the task and not the upload target node cross node uploads work as well.


### Issue Type
- Bugfix Pull Request

### Component Name
proxmox_template

### Contributor's Note
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [x] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #222
