### PR TITLE
feat(inventory): allow to customize ansible_hostname

### DIFF
--- a/changelogs/fragments/471-inventory-custom-ansible_hostname.yaml
+++ b/changelogs/fragments/471-inventory-custom-ansible_hostname.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - inventory - allow to customize generated ansible_hostname (https://github.com/ansible-collections/community.proxmox/pull/471).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: proxmox
-version: 2.1.0
+version: 2.2.0
 readme: README.md
 authors:
   - Ansible community (https://github.com/ansible-community)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@
 
 namespace: community
 name: proxmox
-version: 2.2.0
+version: 2.1.0
 readme: README.md
 authors:
   - Ansible community (https://github.com/ansible-community)

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -160,7 +160,7 @@ DOCUMENTATION = """
           - The available variables are the fields of the cluster resource,
             for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
         type: str
-        version_added: 2.2.0
+        version_added: 2.1.0
       lxc_hostname:
         description:
           - A template for the inventory hostname of LXC containers, overriding O(hostname) for them.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -168,7 +168,7 @@ DOCUMENTATION = """
           - The available variables are the fields of the cluster resource,
             for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
         type: str
-        version_added: 2.2.0
+        version_added: 2.1.0
 """
 
 EXAMPLES = """

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -143,6 +143,15 @@ DOCUMENTATION = """
         type: list
         elements: str
         default: []
+      hostname:
+        description:
+          - A template for the inventory hostname of Proxmox nodes, QEMU VMs and LXC containers.
+          - If not provided, the Proxmox name is used.
+          - For nodes, the available variables are C(name), C(level), C(nodeid), C(online), C(local), C(ip), C(id) and C(type).
+          - For QEMU VMs and LXC containers, the available variables are the fields of the cluster resource,
+            for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
+        type: str
+        version_added: 2.2.0
 """
 
 EXAMPLES = """
@@ -238,6 +247,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable, Constructable
 from ansible.utils.display import Display
+from ansible.utils.vars import combine_vars
 
 from ansible_collections.community.proxmox.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.proxmox.plugins.plugin_utils.unsafe import make_unsafe
@@ -679,6 +689,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not want_facts and want_post_filter_facts:
             self._safe_get_guest_facts(properties, node, vmid, ittype, name)
 
+        # rename the host in the inventory if a hostname template is set
+        hostname_template = self.get_option("hostname")
+        if hostname_template:
+            self.templar.available_variables = combine_vars(dict(item), self._vars)
+            name = self.templar.template(hostname_template)
+
         # add the host to the inventory
         self._add_host(name, properties)
         if is_template:
@@ -700,7 +716,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _populate_pool_groups(self, added_hosts):
         """Generate groups from Proxmox resource pools, ignoring VMs and
-        containers that were skipped."""
+        containers that were skipped. added_hosts maps the Proxmox names of
+        the added guests to their inventory hostnames."""
         for pool in self._get_pools():
             poolid = pool.get("poolid")
             if not poolid:
@@ -711,7 +728,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for member in self._get_members_per_pool(poolid):
                 name = member.get("name")
                 if name and name in added_hosts:
-                    self.inventory.add_child(pool_group, name)
+                    self.inventory.add_child(pool_group, added_hosts[name])
 
     def _populate(self):  # noqa: PLR0912
         # create common groups
@@ -730,23 +747,36 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # gather VMs on nodes
         self._get_auth()
-        hosts = []
+        hosts = {}
         vms_by_node = self._get_vms_by_node()
         vm_items = []
+
+        hostname_template = self.get_option("hostname")
+
         for node in self._get_nodes():
+            hostvars = {}
+            for key, value in node.items():
+                hostvars[key] = value
+
+            if hostname_template:
+                self.templar.available_variables = combine_vars(hostvars, self._vars)
+                hostname = self.templar.template(hostname_template)
+            else:
+                hostname = node["name"]
+
             if not self.exclude_nodes:
-                self.inventory.add_host(node["name"])
-                self.inventory.add_child(nodes_group, node["name"])
+                self.inventory.add_host(hostname)
+                self.inventory.add_child(nodes_group, hostname)
                 if want_proxmox_nodes_ansible_host:
-                    self.inventory.set_variable(node["name"], "ansible_host", node["ip"])
+                    self.inventory.set_variable(hostname, "ansible_host", node["ip"])
 
             if node["online"] != 1:
                 continue
 
             # Setting composite variables
             if not self.exclude_nodes:
-                variables = self.inventory.get_host(node["name"]).get_vars()
-                self._set_composite_vars(self.get_option("compose"), variables, node["name"], strict=self.strict)
+                variables = self.inventory.get_host(hostname).get_vars()
+                self._set_composite_vars(self.get_option("compose"), variables, hostname, strict=self.strict)
 
             # add Qemu and LXC VMs for the node
             if not self.exclude_vms:
@@ -761,7 +791,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             guest_facts = guest_facts_by_item.get((node, ittype, item["vmid"]))
             name = self._handle_item(node, ittype, item, guest_facts=guest_facts)
             if name is not None:
-                hosts.append(name)
+                hosts[item["name"]] = name
 
         # gather vm's in pools
         if not self.exclude_vms:
@@ -772,6 +802,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             raise AnsibleError("This module requires Python Requests 1.1.0 or higher: https://github.com/psf/requests.")
 
         super().parse(inventory, loader, path)
+
+        # Allow using extra variables arguments as template variables (e.g.
+        # '--extra-vars my_var=my_value')
+        self.templar.available_variables = self._vars
 
         # read config from file, this sets 'options'
         self._read_config_data(path)

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -152,7 +152,7 @@ DOCUMENTATION = """
           - For QEMU VMs and LXC containers, the available variables are the fields of the cluster resource,
             for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
         type: str
-        version_added: 2.2.0
+        version_added: 2.1.0
       qemu_hostname:
         description:
           - A template for the inventory hostname of QEMU VMs, overriding O(hostname) for them.

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -146,9 +146,26 @@ DOCUMENTATION = """
       hostname:
         description:
           - A template for the inventory hostname of Proxmox nodes, QEMU VMs and LXC containers.
-          - If not provided, the Proxmox name is used.
+          - For QEMU VMs and LXC containers it is only used when O(qemu_hostname) or O(lxc_hostname) is not set.
+          - If no template applies, the Proxmox name is used.
           - For nodes, the available variables are C(name), C(level), C(nodeid), C(online), C(local), C(ip), C(id) and C(type).
           - For QEMU VMs and LXC containers, the available variables are the fields of the cluster resource,
+            for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
+        type: str
+        version_added: 2.2.0
+      qemu_hostname:
+        description:
+          - A template for the inventory hostname of QEMU VMs, overriding O(hostname) for them.
+          - If neither this nor O(hostname) is provided, the Proxmox name is used.
+          - The available variables are the fields of the cluster resource,
+            for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
+        type: str
+        version_added: 2.2.0
+      lxc_hostname:
+        description:
+          - A template for the inventory hostname of LXC containers, overriding O(hostname) for them.
+          - If neither this nor O(hostname) is provided, the Proxmox name is used.
+          - The available variables are the fields of the cluster resource,
             for example C(name), C(vmid), C(node), C(type), C(status) and C(template).
         type: str
         version_added: 2.2.0
@@ -690,7 +707,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self._safe_get_guest_facts(properties, node, vmid, ittype, name)
 
         # rename the host in the inventory if a hostname template is set
-        hostname_template = self.get_option("hostname")
+        hostname_template = self.get_option(f"{ittype}_hostname") or self.get_option("hostname")
         if hostname_template:
             self.templar.available_variables = combine_vars(dict(item), self._vars)
             name = self.templar.template(hostname_template)

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -7,6 +7,17 @@
 
 import pytest
 from ansible.inventory.data import InventoryData
+from ansible.parsing.dataloader import DataLoader
+from ansible.template import Templar
+
+try:
+    # ansible-core >= 2.19 only templates strings that are marked as trusted
+    from ansible.template import trust_as_template
+except ImportError:
+
+    def trust_as_template(value):
+        return value
+
 
 from ansible_collections.community.proxmox.plugins.inventory.proxmox import InventoryModule
 
@@ -778,6 +789,67 @@ def test_populate_exclude_nodes(inventory, mocker):
     # make sure that nodes are not in the "ungrouped" group
     for node in ["testnode", "testnode2"]:
         assert node not in inventory.inventory.get_groups_dict()["ungrouped"]
+
+
+def test_populate_hostname_template(inventory, mocker):
+    # module settings
+    inventory.proxmox_user = "root@pam"
+    inventory.proxmox_password = "password"
+    inventory.proxmox_url = "https://localhost:8006"
+    inventory.group_prefix = "proxmox_"
+    inventory.facts_prefix = "proxmox_"
+    inventory.strict = False
+    inventory.exclude_nodes = False
+    inventory.exclude_vms = False
+    inventory.templar = Templar(loader=DataLoader())
+    inventory._vars = {}
+
+    opts = {
+        "group_prefix": "proxmox_",
+        "facts_prefix": "proxmox_",
+        "want_facts": True,
+        "facts_concurrency": 1,
+        "want_proxmox_nodes_ansible_host": True,
+        "qemu_extended_statuses": False,
+        "exclude_nodes": False,
+        "exclude_vms": False,
+        "hostname": trust_as_template("{{ name }}.example.com"),
+    }
+
+    # bypass authentication and API fetch calls
+    inventory._get_auth = mocker.MagicMock(side_effect=get_auth)
+    inventory._get_json = mocker.MagicMock(side_effect=get_json)
+    inventory._get_vm_snapshots = mocker.MagicMock(side_effect=get_vm_snapshots)
+    inventory.get_option = mocker.MagicMock(side_effect=get_option(opts))
+    inventory._can_add_host = mocker.MagicMock(return_value=True)
+    inventory._populate()
+
+    # nodes are added under their templated hostname, not the node name
+    host_node = inventory.inventory.get_host("testnode.example.com")
+    assert host_node is not None
+    assert inventory.inventory.get_host("testnode") is None
+    assert inventory.inventory.get_host("testnode2.example.com") is not None
+    assert inventory.inventory.get_host("testnode2") is None
+
+    # templated nodes keep their ansible_host and nodes group membership
+    assert host_node.get_vars()["ansible_host"] == "10.0.10.1"
+    assert host_node in inventory.inventory.groups["proxmox_nodes"].hosts
+
+    # VMs and LXC containers are added under their templated hostname as well
+    host_qemu = inventory.inventory.get_host("test-qemu.example.com")
+    host_lxc = inventory.inventory.get_host("test-lxc.example.com")
+    assert host_qemu is not None
+    assert inventory.inventory.get_host("test-qemu") is None
+    assert host_lxc is not None
+    assert inventory.inventory.get_host("test-lxc") is None
+
+    # renamed guests keep their group memberships and their Proxmox name as a fact
+    assert host_qemu in inventory.inventory.groups["proxmox_all_qemu"].hosts
+    assert host_lxc in inventory.inventory.groups["proxmox_testnode_lxc"].hosts
+    assert host_qemu.get_vars()["proxmox_name"] == "test-qemu"
+
+    # pool members are matched by their Proxmox name but added under the templated hostname
+    assert inventory.inventory.groups["proxmox_pool_test"].hosts == [host_qemu]
 
 
 def test_populate_exclude_vms(inventory, mocker):

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -814,6 +814,7 @@ def test_populate_hostname_template(inventory, mocker):
         "exclude_nodes": False,
         "exclude_vms": False,
         "hostname": trust_as_template("{{ name }}.example.com"),
+        "qemu_hostname": trust_as_template("{{ name }}-{{ vmid }}.qemu.example.com"),
     }
 
     # bypass authentication and API fetch calls
@@ -835,11 +836,14 @@ def test_populate_hostname_template(inventory, mocker):
     assert host_node.get_vars()["ansible_host"] == "10.0.10.1"
     assert host_node in inventory.inventory.groups["proxmox_nodes"].hosts
 
-    # VMs and LXC containers are added under their templated hostname as well
-    host_qemu = inventory.inventory.get_host("test-qemu.example.com")
-    host_lxc = inventory.inventory.get_host("test-lxc.example.com")
+    # QEMU VMs use the dedicated qemu_hostname template
+    host_qemu = inventory.inventory.get_host("test-qemu-101.qemu.example.com")
     assert host_qemu is not None
     assert inventory.inventory.get_host("test-qemu") is None
+    assert inventory.inventory.get_host("test-qemu.example.com") is None
+
+    # LXC containers have no lxc_hostname set and fall back to the hostname template
+    host_lxc = inventory.inventory.get_host("test-lxc.example.com")
     assert host_lxc is not None
     assert inventory.inventory.get_host("test-lxc") is None
 


### PR DESCRIPTION
### What does this PR do?
This MR allows to change the ansible_host bases not variable. It default to the node name

### Issue Type
- Feature Pull Request

### Component Name
inventory

### Contributor's Note
- [] I have run `nox` and fixed any issues.
- [x] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [ ] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

Fixes #37

---

This PR is partially AI generated.