### PR TITLE
fix(inventory): resolve 501 on nested pool IDs

### DIFF
--- a/changelogs/fragments/472-proxmox-inventory-nested-pools.yml
+++ b/changelogs/fragments/472-proxmox-inventory-nested-pools.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox inventory - fetch pool members via the ``GET /pools?poolid=<id>`` query form instead of the deprecated ``GET /pools/{poolid}`` path form, which returned a 501 error and aborted inventory parsing for nested pool IDs (poolid containing a slash, e.g. ``parent/child``) introduced in Proxmox VE 8.1 (https://github.com/ansible-collections/community.proxmox/issues/472).

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -406,8 +406,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _get_members_per_pool(self, pool):
         display.vvv(f"Fetching Proxmox pool members for {pool}")
-        ret = self._get_json(f"{self.proxmox_url}/api2/json/pools/{pool}")
-        members = ret["members"]
+        ret = self._get_json(f"{self.proxmox_url}/api2/json/pools?{urlencode({'poolid': pool})}")
+        members = ret[0]["members"]
         display.vvv(f"Fetched {len(members)} Proxmox pool members for {pool}")
         return members
 

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -204,30 +204,33 @@ API_RESPONSES = {
             "status": "stopped",
         },
     ],
-    "https://localhost:8006/api2/json/pools/test": {
-        "members": [
-            {
-                "uptime": 1000,
-                "template": 0,
-                "id": "qemu/101",
-                "mem": 1000,
-                "status": "running",
-                "cpu": 0.01,
-                "maxmem": 1000,
-                "diskwrite": 1000,
-                "name": "test-qemu",
-                "netout": 1000,
-                "netin": 1000,
-                "vmid": 101,
-                "node": "testnode",
-                "maxcpu": 1,
-                "type": "qemu",
-                "maxdisk": 1000,
-                "disk": 0,
-                "diskread": 1000,
-            },
-        ],
-    },
+    "https://localhost:8006/api2/json/pools?poolid=test": [
+        {
+            "poolid": "test",
+            "members": [
+                {
+                    "uptime": 1000,
+                    "template": 0,
+                    "id": "qemu/101",
+                    "mem": 1000,
+                    "status": "running",
+                    "cpu": 0.01,
+                    "maxmem": 1000,
+                    "diskwrite": 1000,
+                    "name": "test-qemu",
+                    "netout": 1000,
+                    "netin": 1000,
+                    "vmid": 101,
+                    "node": "testnode",
+                    "maxcpu": 1,
+                    "type": "qemu",
+                    "maxdisk": 1000,
+                    "disk": 0,
+                    "diskread": 1000,
+                },
+            ],
+        },
+    ],
     "https://localhost:8006/api2/json/nodes/testnode/network": [
         {
             "families": ["inet"],
@@ -827,7 +830,7 @@ def test_populate_exclude_vms(inventory, mocker):
     assert "https://localhost:8006/api2/json/nodes/testnode/qemu" not in called_urls
     assert "https://localhost:8006/api2/json/nodes/testnode/lxc" not in called_urls
     assert "https://localhost:8006/api2/json/pools" not in called_urls
-    assert "https://localhost:8006/api2/json/pools/test" not in called_urls
+    assert "https://localhost:8006/api2/json/pools?poolid=test" not in called_urls
 
 
 def test_get_guest_facts_by_item_concurrent(inventory, mocker):
@@ -989,3 +992,17 @@ def test_handle_item_adds_dynamic_status_group(inventory, mocker):
     assert (
         inventory.inventory.get_host("test-qemu-prelaunch") in inventory.inventory.groups["proxmox_all_prelaunch"].hosts
     )
+
+
+def test_get_members_per_pool_uses_query_form_for_nested_pool(inventory, mocker):
+    inventory.proxmox_url = "https://localhost:8006"
+
+    def fake_get_json(url, ignore_errors=None):
+        return [{"poolid": "test/nested", "members": [{"name": "test-qemu", "vmid": 101}]}]
+
+    inventory._get_json = mocker.MagicMock(side_effect=fake_get_json)
+
+    members = inventory._get_members_per_pool("test/nested")
+
+    inventory._get_json.assert_called_once_with("https://localhost:8006/api2/json/pools?poolid=test%2Fnested")
+    assert members == [{"name": "test-qemu", "vmid": 101}]


### PR DESCRIPTION
### What does this PR do?
The proxmox inventory plugin aborted the entire inventory parse with a 501 error when the cluster contained a nested pool a poolid with a slash, e.g. parent/child`(PVE 8.1+):

501 Server Error: Method 'GET /pools/parent/child' not implemented

`_get_members_per_pool()` fetched members with the deprecated path form `GET /pools/{poolid}`, which cannot carry a slash. Since `_populate_pool_groups()` queries every pool with no opt-out, one nested pool broke the whole inventory.

This switches to the query form `GET /pools?poolid=<id>` and reads `ret[0]["members"]` identical to what `module_utils.proxmox.get_pool()` (`pools.get(poolid=poolid)[0]`) already does, and which `proxmox_pool` / `proxmox_pool_member` (the modules fixed for nested pools in #316 / #428) rely on to read members. Flat pools are unaffected: the query form returns the same data the path form did.

### Issue Type
- Bugfix Pull Request

### Component Name
proxmox inventory plugin

### Contributor's Note
- [x] I have run `nox` and fixed any issues.
- [x] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [ ] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

Fixes #472