### PR TITLE
fix(proxmox_qemu_api): export HOME and guarantee tilde expansion for guest agent commands

### DIFF
--- a/changelogs/fragments/461-qemu-agent-home-guard.yml
+++ b/changelogs/fragments/461-qemu-agent-home-guard.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_qemu_api connection plugin - export ``HOME`` for every command executed through the QEMU guest agent, which starts processes without a login environment. With ``HOME`` unset, POSIX sh left ``~`` unexpanded, breaking ansible-core's remote tmpdir discovery and causing ``copy``, ``template`` and module payload transfers to fail after creating a literal ``/~`` directory on the guest (https://github.com/ansible-collections/community.proxmox/issues/461).

--- a/plugins/connection/proxmox_qemu_api.py
+++ b/plugins/connection/proxmox_qemu_api.py
@@ -219,6 +219,14 @@ for _name in ("urllib3", "requests", "py.warnings"):
 FILE_WRITE_CHUNK = 45000
 FILE_WRITE_RETRIES = 5
 
+# The QEMU guest agent starts processes without a login environment, so HOME is
+# unset. POSIX sh (dash) then leaves ``~`` unexpanded, which breaks ansible-core's
+# remote tmpdir discovery (``echo ~``) and makes it create a literal ``/~`` directory.
+# Exporting HOME up-front fixes tilde expansion for the command itself and for any
+# child process it spawns, including ansible-core's inner ``/bin/sh -c`` wrapper and
+# the Python module interpreter.
+HOME_GUARD = 'export HOME="${HOME:-$(getent passwd "$(id -u)" | cut -d: -f6)}"; '
+
 
 class Connection(ConnectionBase):
     """Connection plugin that uses the Proxmox QEMU Guest Agent API."""
@@ -315,7 +323,7 @@ class Connection(ConnectionBase):
         display.vvv(f"EXEC via guest agent: {cmd}")
 
         try:
-            data = self._agent().exec.post(command=[shell, "-c", cmd])
+            data = self._agent().exec.post(command=[shell, "-c", HOME_GUARD + cmd])
         except Exception as exc:
             raise AnsibleConnectionFailure(f"Failed to execute command on VM {self.get_option('vmid')}: {exc}") from exc
 

--- a/tests/unit/plugins/connection/test_proxmox_qemu_api.py
+++ b/tests/unit/plugins/connection/test_proxmox_qemu_api.py
@@ -218,7 +218,7 @@ def test_exec_command_success(mock_api, mock_sleep, connection):
     assert rc == 0
     assert stdout == "hello\n"
     assert stderr == ""
-    agent.exec.post.assert_called_once_with(command=["/bin/sh", "-c", "echo hello"])
+    agent.exec.post.assert_called_once_with(command=["/bin/sh", "-c", qemu_module.HOME_GUARD + "echo hello"])
 
 
 @patch.object(qemu_module.time, "sleep")
@@ -255,6 +255,76 @@ def test_exec_command_api_failure(mock_api, connection):
 
     with pytest.raises(AnsibleConnectionFailure, match="Failed to execute command"):
         connection.exec_command("echo hello")
+
+
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
+def test_exec_command_exports_home(mock_api, mock_sleep, connection):
+    """Test that exec_command prefixes the HOME guard (issue #461).
+
+    guest-exec provides no login environment, so HOME is unset and POSIX sh
+    (dash) leaves ``~`` unexpanded, breaking ansible-core's remote tmpdir
+    discovery. The guard must be prepended to every command.
+    """
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 42}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 0, "out-data": "/root\n", "err-data": ""}
+
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    connection.exec_command("echo ~")
+
+    cmd = agent.exec.post.call_args[1]["command"]
+    assert cmd[0] == "/bin/sh"
+    assert cmd[1] == "-c"
+    assert cmd[2].startswith('export HOME="${HOME:-')
+    assert cmd[2].endswith("echo ~")
+
+
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
+def test_exec_command_home_guard_respects_existing_home(mock_api, mock_sleep, connection):
+    """Test that the HOME guard uses default-if-unset expansion.
+
+    ``${HOME:-...}`` must preserve a HOME that is already set, only filling it
+    in from the passwd database when it is missing or empty.
+    """
+    assert '"${HOME:-' in qemu_module.HOME_GUARD
+    assert "getent passwd" in qemu_module.HOME_GUARD
+    # The guard must be a single prefix statement terminated by ';' so the
+    # user command executes unconditionally afterwards.
+    assert qemu_module.HOME_GUARD.rstrip().endswith(";")
+
+
+@patch.object(qemu_module.time, "sleep")
+@patch.object(qemu_module, "ProxmoxAPI")
+def test_exec_command_home_guard_with_custom_executable(mock_api, mock_sleep, connection):
+    """Test that the HOME guard is applied regardless of the configured executable.
+
+    ansible-core wraps its own commands in an inner ``/bin/sh -c`` (dash) no
+    matter what ``executable`` is set to, so the exported HOME must come from
+    the outer wrapper to be inherited by that child shell (issue #461).
+    """
+    mock_proxmox = MagicMock()
+    mock_api.return_value = mock_proxmox
+    connection.set_option("executable", "/usr/bin/bash")
+
+    agent = mock_proxmox.nodes("pve-1").qemu(TEST_VMID).agent
+    agent.exec.post.return_value = {"pid": 42}
+    agent("exec-status").get.return_value = {"exited": 1, "exitcode": 0, "out-data": "", "err-data": ""}
+
+    connection._connected = True
+    connection._proxmox = mock_proxmox
+
+    connection.exec_command("/bin/sh -c 'echo ~'")
+
+    cmd = agent.exec.post.call_args[1]["command"]
+    assert cmd[0] == "/usr/bin/bash"
+    assert cmd[2].startswith("export HOME=")
 
 
 @patch.object(qemu_module.time, "sleep")


### PR DESCRIPTION
## SUMMARY

The QEMU guest agent starts processes without a login environment, so `HOME`
is unset. POSIX `sh` (dash) then leaves `~` unexpanded, which breaks
ansible-core's remote tmpdir discovery and causes `copy`/`template`/module
transfers to fail after creating a literal `/~` directory on the guest.

This exports `HOME` for every command executed through the guest agent by
prefixing it, since the PVE `agent/exec` endpoint accepts no `env`
parameter. Because the exported variable is inherited by child processes,
this also fixes ansible-core's inner `/bin/sh -c` wrapper regardless of the
configured `executable` — see the linked issue comment for the reproduction
showing `ansible_executable: /usr/bin/bash` failing for a related reason.

Reproduced and verified end-to-end against a real Proxmox VE 9.1.0 node with
a Debian 13 guest; see the evidence logs on the issue for full `-vvv` traces
before and after the fix.

Fixes #461

## ISSUE TYPE

- Bugfix Pull Request

## COMPONENT NAME

proxmox_qemu_api

## ADDITIONAL INFORMATION

Discussed the approach and four open design questions on #461 before
opening this PR. Happy to adjust based on review, in particular I left out
defensive `~` expansion in `put_file`/`fetch_file` for a minimal diff, since
after this fix ansible-core only ever hands them absolute paths in the
normal flow.
