### PR TITLE
Allow password change with local backend, closes #482

### DIFF
--- a/changelogs/fragments/482-allow-password-change.yml
+++ b/changelogs/fragments/482-allow-password-change.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_user - allow password change with e.g. local backend (https://github.com/ansible-collections/community.proxmox/issues/482).

--- a/plugins/modules/proxmox_user.py
+++ b/plugins/modules/proxmox_user.py
@@ -385,16 +385,16 @@ class ProxmoxUserAnsible(ProxmoxAnsible):
                         changed=False, userid=userid, msg=f"Failed to update user with ID {userid}: {e}"
                     )
 
-            # The password cannot be updated when using API Token authentication
-            if password and self.module.params["api_token_id"]:
-                self.module.warn(
-                    "Password cannot be updated when using API Token authentication. Ignoring password parameter.",
-                )
-                self.module.exit_json(changed=False, userid=userid, msg=f"User {userid} already up to date")
-
             # We have no way of testing if the user's password needs to be changed
             # so, if it's provided we will update it anyway
-            if password and self.module.params["api_token_id"]:
+            if password:
+                # The password cannot be updated when using API Token authentication
+                if self.module.params["api_token_id"]:
+                    self.module.warn(
+                        "Password cannot be updated when using API Token authentication. Ignoring password parameter.",
+                    )
+                    self.module.exit_json(changed=False, userid=userid, msg=f"User {userid} already up to date")
+
                 try:
                     self.proxmox_api.access.password.put(userid=userid, password=password)
                     self.module.exit_json(changed=True, userid=userid, msg=f"User {userid} updated")


### PR DESCRIPTION
### What does this PR do?

The current code only allows password changes when a password is supplied *and* token auth is used. The same condition is checked earlier and leads to an early exit. 

For auth methods without a token (password, local backend), password changes work and should be allowed.

### Issue Type
- Bugfix Pull Request

### Component Name
community.proxmox.proxmox_user

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [ ] I have considered backward compatibility.
- [ ] I haved added a changelog fragment (expect for new a module).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #482
