### PR TITLE
fix(firewall_info): get aliases and ipsets only for level cluster and vm

### DIFF
--- a/changelogs/fragments/485-proxmox-firewall-info-ipsets-aliases.yaml
+++ b/changelogs/fragments/485-proxmox-firewall-info-ipsets-aliases.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_firewall_info - skip aliases and ipsets API calls for firewall for node, vnet and group (https://github.com/ansible-collections/community.proxmox/pull/485).

--- a/plugins/modules/proxmox_firewall_info.py
+++ b/plugins/modules/proxmox_firewall_info.py
@@ -78,7 +78,7 @@ groups:
 ip_sets:
     description:
       - List of IP Sets.
-      - These are only supported on the O(level) = cluster, other inputs are ignored.
+      - These are only supported at O(level=cluster) and O(level=vm); other levels return an empty list.
     returned: on success
     type: list
     elements: dict
@@ -315,8 +315,10 @@ class ProxmoxFirewallInfoAnsible(ProxmoxSdnAnsible):
 
         rules = self.get_fw_rules(rules_obj, pos=self.params.get("pos"))
         groups = self.get_groups()
-        aliases = self.get_aliases(firewall_obj=firewall_obj)
-        ip_sets = self.get_ip_sets(firewall_obj=firewall_obj)
+        aliases_firewall_obj = firewall_obj if level in ("cluster", "vm") else None
+        ip_sets_firewall_obj = firewall_obj if level in ("cluster", "vm") else None
+        aliases = self.get_aliases(firewall_obj=aliases_firewall_obj)
+        ip_sets = self.get_ip_sets(firewall_obj=ip_sets_firewall_obj)
         self.module.exit_json(
             changed=False,
             firewall_rules=rules,

--- a/tests/integration/targets/proxmox_firewall_info/aliases
+++ b/tests/integration/targets/proxmox_firewall_info/aliases
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+unsupported
+proxmox_firewall_info

--- a/tests/integration/targets/proxmox_firewall_info/defaults/main.yml
+++ b/tests/integration/targets/proxmox_firewall_info/defaults/main.yml
@@ -1,0 +1,5 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+node: pve

--- a/tests/integration/targets/proxmox_firewall_info/meta/main.yml
+++ b/tests/integration/targets/proxmox_firewall_info/meta/main.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+dependencies:
+  - setup_proxmox_auth

--- a/tests/integration/targets/proxmox_firewall_info/tasks/main.yml
+++ b/tests/integration/targets/proxmox_firewall_info/tasks/main.yml
@@ -1,0 +1,25 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+---
+- name: Proxmox firewall info
+  tags: ["firewall"]
+  environment: "{{ environment_auth_vars }}"
+
+  block:
+    - name: Get node firewall configuration
+      community.proxmox.proxmox_firewall_info:
+        level: node
+        node: "{{ node }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result is success
+          - result.aliases == []
+          - result.ip_sets == []
+          - result.firewall_rules is defined
+          - result.firewall_rules is iterable
+          - result.groups is defined
+          - result.groups is iterable

--- a/tests/unit/plugins/modules/test_proxmox_firewall_info.py
+++ b/tests/unit/plugins/modules/test_proxmox_firewall_info.py
@@ -186,3 +186,17 @@ class TestProxmoxFirewallModule(ModuleTestCase):
         assert result["firewall_rules"] == RAW_FIREWALL_RULES
         assert result["groups"] == ["test1", "test2"]
         assert result["aliases"] == RAW_ALIASES
+
+    def test_aliases_and_ipsets_are_empty(self):
+        cases = [
+            ("node", {"node": "pve-test"}),
+            ("vnet", {"vnet": "vnet-test"}),
+            ("group", {"group": "group-test"}),
+        ]
+        for level, extra_args in cases:
+            with self.subTest(level=level, extra_args=extra_args):
+                with pytest.raises(SystemExit) as exc_info, set_module_args(get_module_args(level=level, **extra_args)):
+                    self.module.main()
+                result = exc_info.value.args[0]
+                assert result["aliases"] == []
+                assert result["ip_sets"] == []


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Fixes `proxmox_firewall_info` by removing the API calls to get aliases and ipsets when the level is not `cluster` or `vm`.

The integration test added is voluntarily minimal in order to be easily run instead of testing all levels separetely (which requires vm, vnet, ..). 

### Issue Type
<!--- Pick one below and delete the rest. -->
- Bugfix Pull Request

### Component Name
<!--- Write the short name of the module, plugin, task or feature below -->

 `proxmox_firewall_info`

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [x] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [x] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).



<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #486
