### PR TITLE
Fix: Allow using auth token as documented

### DIFF
--- a/changelogs/fragments/475-token-authentication-format.yaml
+++ b/changelogs/fragments/475-token-authentication-format.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "All modules - support both API token authentication formats: ``api_token_id: username@realm!tokenid`` (recommended) and ``api_user: username@realm`` with ``api_token_id: tokenid``. Previously, the documented format with embedded user in the token ID was not working (https://github.com/ansible-collections/community.proxmox/issues/475)."

--- a/docs/docsite/rst/guides.rst
+++ b/docs/docsite/rst/guides.rst
@@ -27,10 +27,23 @@ Examples below show authentication variables as you would typically define them 
 
 **API Token**
 
+You can use API tokens in two formats:
+
+*Format 1: Full token ID (recommended)*
+
 .. code-block:: yaml
 
    api_host: 10.0.0.1
    api_token_id: username@realm!tokenid
+   api_token_secret: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+*Format 2: Separate user and token ID*
+
+.. code-block:: yaml
+
+   api_host: 10.0.0.1
+   api_user: username@realm
+   api_token_id: tokenid
    api_token_secret: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 **Username/password**

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -238,7 +238,7 @@ class ProxmoxAnsible:
                     # Format: username@realm!tokenid
                     auth_args["user"], auth_args["token_name"] = api_token_id.split("!", maxsplit=1)
                 else:
-                    # Format: tokenid (user provided separately or defaults to "root@pam")
+                    # Format: tokenid (user provided separately)
                     auth_args["user"] = api_user
                     auth_args["token_name"] = api_token_id
                 auth_args["token_value"] = api_token_secret

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -236,8 +236,7 @@ class ProxmoxAnsible:
                 # Token authentication: parse api_token_id if it contains the user part
                 if api_token_id and "!" in api_token_id:
                     # Format: username@realm!tokenid
-                    auth_args["user"] = api_token_id.split("!")[0]
-                    auth_args["token_name"] = api_token_id.split("!")[-1]
+                    auth_args["user"], auth_args["token_name"] = api_token_id.split("!", maxsplit=1)
                 else:
                     # Format: tokenid (user provided separately or defaults to "root@pam")
                     auth_args["user"] = api_user

--- a/plugins/module_utils/proxmox.py
+++ b/plugins/module_utils/proxmox.py
@@ -229,12 +229,19 @@ class ProxmoxAnsible:
             if api_port:
                 auth_args["port"] = api_port
 
-            auth_args["user"] = api_user
-
             if api_password:
+                auth_args["user"] = api_user
                 auth_args["password"] = api_password
             else:
-                auth_args["token_name"] = api_token_id
+                # Token authentication: parse api_token_id if it contains the user part
+                if api_token_id and "!" in api_token_id:
+                    # Format: username@realm!tokenid
+                    auth_args["user"] = api_token_id.split("!")[0]
+                    auth_args["token_name"] = api_token_id.split("!")[-1]
+                else:
+                    # Format: tokenid (user provided separately or defaults to "root@pam")
+                    auth_args["user"] = api_user
+                    auth_args["token_name"] = api_token_id
                 auth_args["token_value"] = api_token_secret
 
             auth_args["verify_ssl"] = validate_certs


### PR DESCRIPTION
### What does this PR do?
Allows for using token_id format as documented

### Issue Type
<!--- Pick one below and delete the rest. -->
- Bugfix Pull Request

### Component Name
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_user

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [x] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [x] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).


I've not added any unit tests, as current authentication also does not have any. It is currently mocked.

I was unable to run integration tests fully on my system due to missing some dependencies, but I've checked them out to be used in my own ansible scripts and tested them.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #475 

Full disclosure: I've used copilot to generate this patch, however, I've reviewed the changes and stand by them as if they were my own.