### PR TITLE
Corrected 'authorized-keys' to 'authorized_keys'

### DIFF
--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -256,11 +256,11 @@ EXAMPLES = r"""
 # $ mkdir -p /opt/ansible-pct/.ssh
 # $ ssh-keygen -t ed25519 -C 'ansible' -N "" -f /opt/ansible-pct/.ssh/ansible <<< y > /dev/null
 # $ cat /opt/ansible-pct/.ssh/ansible
-# $ mv /opt/ansible-pct/.ssh/ansible.pub /opt/ansible-pct/.ssh/authorized-keys
+# $ mv /opt/ansible-pct/.ssh/ansible.pub /opt/ansible-pct/.ssh/authorized_keys
 # $ rm /opt/ansible-pct/.ssh/ansible*
 # $ chown -R ansible:ansible /opt/ansible-pct/.ssh
 # $ chmod 700 /opt/ansible-pct/.ssh
-# $ chmod 600 /opt/ansible-pct/.ssh/authorized-keys
+# $ chmod 600 /opt/ansible-pct/.ssh/authorized_keys
 # $ echo 'ansible ALL = (root) NOPASSWD: /usr/sbin/pct' > /etc/sudoers.d/ansible_pct
 #
 # Save the displayed private key and add it to your ssh-agent
@@ -303,7 +303,7 @@ EXAMPLES = r"""
 #     - name: Set public key as authorized key
 #       ansible.builtin.copy:
 #         src: /opt/ansible-pct/.ssh/ansible.pub
-#         dest: /opt/ansible-pct/.ssh/authorized-keys
+#         dest: /opt/ansible-pct/.ssh/authorized_keys
 #         remote_src: yes
 #         owner: ansible
 #         group: ansible


### PR DESCRIPTION
### What does this PR do?
Corrects 'authorized-keys' to 'authorized_keys' in the setup example.

### Issue Type
<!--- Pick one below and delete the rest. -->
- Docs Pull Request

### Component Name
<!--- Write the short name of the module, plugin, task or feature below -->
proxmox_pct_remote

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [ ] I have considered backward compatibility.
- [ ] I haved added a changelog fragment (expect for new a module).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
<!--- Fixes #0000 | Relates #0000 --->
