### PR TITLE
fix(inventory): pass verify= on requests when validate_certs is set

### DIFF
--- a/changelogs/fragments/inventory-validate-certs-requests-ca-bundle.yml
+++ b/changelogs/fragments/inventory-validate-certs-requests-ca-bundle.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "proxmox inventory - pass ``verify`` explicitly on HTTP requests so ``validate_certs: false`` is honored when ``REQUESTS_CA_BUNDLE`` is set (regression when only ``session.verify`` was used) (https://github.com/ansible-collections/community.proxmox/pull/491)."

--- a/plugins/inventory/proxmox.py
+++ b/plugins/inventory/proxmox.py
@@ -310,6 +310,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 self.display.vvv('Skipping due to inventory source not ending in "proxmox.yaml" nor "proxmox.yml"')
         return valid
 
+    def _get_verify(self):
+        return self.get_option("validate_certs")
+
     def _get_session(self):
         session = getattr(self._thread_local, "session", None)
         if session is None:
@@ -317,13 +320,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             session.headers.update(
                 {"User-Agent": f"ansible {ansible_version} Python {python_version.split(' ', 1)[0]}"}
             )
-            session.verify = self.get_option("validate_certs")
-            if not session.verify:
+            verify = self._get_verify()
+            session.verify = verify
+            if not verify:
                 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             self._thread_local.session = session
         return session
 
     def _get_auth(self):
+        verify = self._get_verify()
         if self.proxmox_password:
             credentials = urlencode({"username": self.proxmox_user, "password": self.proxmox_password})
             a = self._get_session()
@@ -331,6 +336,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 f"{self.proxmox_url}/api2/json/access/ticket",
                 data=credentials,
                 timeout=self.api_timeout,
+                verify=verify,
             )
             json = ret.json()
             self.headers = {
@@ -363,8 +369,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if not has_data:
             s = self._get_session()
+            verify = self._get_verify()
             while True:
-                ret = s.get(url, headers=self.headers, timeout=self.api_timeout)
+                ret = s.get(url, headers=self.headers, timeout=self.api_timeout, verify=verify)
                 if ignore_errors and ret.status_code in ignore_errors:
                     break
                 ret.raise_for_status()

--- a/tests/unit/plugins/inventory/test_proxmox.py
+++ b/tests/unit/plugins/inventory/test_proxmox.py
@@ -1026,12 +1026,14 @@ def test_get_json_uses_api_timeout(inventory, mocker):
     session = mocker.MagicMock()
     session.get.return_value = response
     inventory._get_session = mocker.MagicMock(return_value=session)
+    inventory.get_option = mocker.MagicMock(return_value=True)
 
     assert inventory._get_json("https://localhost:8006/api2/json/test") == [{"name": "test"}]
     session.get.assert_called_once_with(
         "https://localhost:8006/api2/json/test",
         headers={},
         timeout=12,
+        verify=True,
     )
 
 


### PR DESCRIPTION
## Summary

Homelab and CI setups often set `validate_certs: false` in the Proxmox inventory plugin when connecting to PVE's self-signed HTTPS API. That option is supposed to skip certificate verification, but in many environments it silently does nothing.

**What users see:** `ansible-inventory` fails with `SSL: CERTIFICATE_VERIFY_FAILED` even though `validate_certs: false` is set in the inventory file.

**Why:** The plugin only set `session.verify` on the shared `requests` session. When `REQUESTS_CA_BUNDLE` is set in the environment (common in devcontainers, CI images, and hardened Python installs), recent `requests`/`urllib3` still verify TLS and ignore `session.verify=False`. You have to pass `verify=` on each request.

**Fix:** Read `validate_certs` once and pass `verify=` explicitly on the inventory plugin's `GET` and `POST` calls (password auth ticket request included). No new options; behaviour matches what the docs already promise.

Same class of fix as ansible-collections/community.general#9178.

**Note:** This does not address hostname mismatch (e.g. inventory `url` uses an IP but the node cert is issued for `pve.localdomain`). That still requires the correct hostname or a trusted cert for the URL you use. Only the "skip verification" path is fixed here.

## Test plan

- [x] Reproduced: `validate_certs: false` fails with `REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` before patch
- [x] After patch: `ansible-inventory` succeeds with `validate_certs: false` and `REQUESTS_CA_BUNDLE` set
- [x] `validate_certs: true` unchanged where verification already worked