### PR TITLE
fix(proxmox_pct_remote): restore missing _raise_paramiko_connect_exception helper

### DIFF
--- a/changelogs/fragments/477-pct-remote-restore-connect-error-translation.yml
+++ b/changelogs/fragments/477-pct-remote-restore-connect-error-translation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_pct_remote connection plugin - restore the ``_raise_paramiko_connect_exception`` helper that was referenced but not defined after a refactor, so unexpected SSH connection errors (connection refused, timeouts) are reported as ``AnsibleConnectionFailure`` with the real error message instead of crashing with ``AttributeError`` (https://github.com/ansible-collections/community.proxmox/issues/477).

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -595,19 +595,6 @@ class Connection(ConnectionBase):
             self._raise_paramiko_connect_exception(e, port)
 
     def _raise_paramiko_connect_exception(self, e: Exception, port: int) -> t.NoReturn:
-        """Translate an unexpected Paramiko connect error into an Ansible failure.
-
-        Restores the error translation that was inlined in ``_connect`` before
-        the refactor in #372 extracted ``_paramiko_connect_ssh`` and referenced
-        this helper without defining it (issue #477). Without it, any
-        unexpected connection error (e.g. connection refused, timeouts,
-        ``NoValidConnectionsError``) crashed with ``AttributeError`` instead of
-        reporting the real failure.
-
-        Uses ``get_option`` (singular); the pre-refactor code called
-        ``get_options('remote_addr')``, which would have rendered the entire
-        options dict - including the password - into the error message.
-        """
         msg = to_text(e)
         if "PID check failed" in msg:
             raise AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible") from e

--- a/plugins/connection/proxmox_pct_remote.py
+++ b/plugins/connection/proxmox_pct_remote.py
@@ -594,6 +594,30 @@ class Connection(ConnectionBase):
         except Exception as e:
             self._raise_paramiko_connect_exception(e, port)
 
+    def _raise_paramiko_connect_exception(self, e: Exception, port: int) -> t.NoReturn:
+        """Translate an unexpected Paramiko connect error into an Ansible failure.
+
+        Restores the error translation that was inlined in ``_connect`` before
+        the refactor in #372 extracted ``_paramiko_connect_ssh`` and referenced
+        this helper without defining it (issue #477). Without it, any
+        unexpected connection error (e.g. connection refused, timeouts,
+        ``NoValidConnectionsError``) crashed with ``AttributeError`` instead of
+        reporting the real failure.
+
+        Uses ``get_option`` (singular); the pre-refactor code called
+        ``get_options('remote_addr')``, which would have rendered the entire
+        options dict - including the password - into the error message.
+        """
+        msg = to_text(e)
+        if "PID check failed" in msg:
+            raise AnsibleError("paramiko version issue, please upgrade paramiko on the machine running ansible") from e
+        if "Private key file is encrypted" in msg:
+            msg = (
+                f"ssh {self.get_option('remote_user')}@{self.get_option('remote_addr')}:{port} : "
+                f"{msg}\nTo connect as a different user, use -u <username>."
+            )
+        raise AnsibleConnectionFailure(msg) from e
+
     def _connect(self) -> Connection:
         """Open an SSH session to the Proxmox host via Paramiko."""
 

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -605,3 +605,51 @@ def test_reset(connection):
     connection._connected = False
     connection.reset()
     assert connection.close.call_count == 1
+
+
+@patch("paramiko.SSHClient")
+def test_connect_generic_exception_translated(mock_ssh, connection):
+    """Test that unexpected connect errors raise AnsibleConnectionFailure, not AttributeError (issue #477).
+
+    NoValidConnectionsError, socket timeouts and other OSErrors are not
+    subclasses of BadHostKeyException/AuthenticationException, so they reach
+    the generic handler, which must translate them instead of crashing.
+    """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_client.connect.side_effect = OSError("Connection refused")
+
+    with pytest.raises(AnsibleConnectionFailure, match="Connection refused"):
+        connection._connect()
+
+
+@patch("paramiko.SSHClient")
+def test_connect_pid_check_failed_raises_ansible_error(mock_ssh, connection):
+    """Test that the legacy paramiko 'PID check failed' error keeps its dedicated message."""
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_client.connect.side_effect = Exception("PID check failed")
+
+    with pytest.raises(AnsibleError, match="paramiko version issue"):
+        connection._connect()
+
+
+@patch("paramiko.SSHClient")
+def test_connect_error_message_does_not_leak_options(mock_ssh, connection):
+    """Test that the translated error message does not embed the full options dict.
+
+    The pre-refactor code called ``self.get_options('remote_addr')`` (plural),
+    which would have rendered every connection option - including the password -
+    into the error message. The restored helper must use ``get_option``.
+    """
+    mock_client = MagicMock()
+    mock_ssh.return_value = mock_client
+    mock_client.connect.side_effect = Exception("Private key file is encrypted")
+
+    with pytest.raises(AnsibleConnectionFailure) as excinfo:
+        connection._connect()
+
+    message = str(excinfo.value)
+    assert "root@192.168.1.100:22" in message
+    assert "To connect as a different user" in message
+    assert "password" not in message

--- a/tests/unit/plugins/connection/test_proxmox_pct_remote.py
+++ b/tests/unit/plugins/connection/test_proxmox_pct_remote.py
@@ -495,7 +495,7 @@ def test_close_lock_file_time_out_error_handling(mock_exists, mock_unlink, conne
 @patch("os.chown")
 @patch("os.rename")
 @patch("os.path.exists")
-def test_tempfile_creation_and_move(  # noqa: PLR0913
+def test_tempfile_creation_and_move(  # noqa: PLR0913, PLR0917, PLR0917
     mock_exists, mock_rename, mock_chown, mock_chmod, mock_tempfile, mock_lock_file, connection
 ):
     """Test tempfile creation and move during close"""


### PR DESCRIPTION
## SUMMARY

`proxmox_pct_remote` calls `self._raise_paramiko_connect_exception(e, port)` in
its generic connect-error handler, but that method does not exist anywhere in
the collection. `git log -S` pins its disappearance to 0ffe419 (PR #372), a
ruff style refactor that extracted `_paramiko_connect_ssh()` and replaced the
inline error-translation block with a call to a helper it never added.

Any connect error other than a bad host key or an authentication failure,
connection refused, timeouts, `NoValidConnectionsError`, DNS failures,
therefore crashes with `AttributeError`, hiding the real reason.

It also misclassifies the host: because `AttributeError` propagates as an
ordinary exception rather than `AnsibleConnectionFailure`, ansible-core records
the host as failed instead of unreachable, which changes behaviour for
`ignore_unreachable`, `max_fail_percentage`, `serial`, and retry files.

This restores the helper with the pre-refactor behaviour, using `get_option()`
rather than the original `get_options()`, the latter returns the whole options
dict and would have rendered the password into the error message.

Reproduced and verified end-to-end against a real Proxmox VE 9.1.0 node with a
Debian 13 LXC, before/after logs are attached to the issue.

Fixes #477

## ISSUE TYPE

- Bugfix Pull Request

## COMPONENT NAME

proxmox_pct_remote

## ADDITIONAL INFORMATION

I've discussed on #477 before opening this PR. Three unit tests cover the restored
behaviour, verified red (`3 failed, 31 passed` against upstream's copy of the
plugin) then green (`34 passed`). `ansible-test sanity` and the repository
pre-commit hooks pass. Changelog fragment included.

One point raised on the issue and carried here:

I used `get_option()` where the pre-#372 code used `get_options()`. That is
a deliberate deviation from a literal restoration, since the original would
have leaked every connection option including the password into the error
text. A unit test asserts the password does not appear.

