### PR TITLE
Omit "pos" for API that does not support it, closes #485

### DIFF
--- a/changelogs/fragments/485-omit-unknown-api-parameter.yml
+++ b/changelogs/fragments/485-omit-unknown-api-parameter.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_firewall - omit unsupported "pos" API parameter (https://github.com/ansible-collections/community.proxmox/issues/485).

--- a/plugins/modules/proxmox_firewall.py
+++ b/plugins/modules/proxmox_firewall.py
@@ -710,7 +710,7 @@ class ProxmoxFirewallAnsible(ProxmoxSdnAnsible):
                 self.module.exit_json(changed=False, msg="Firewall rule already doesn't exist")
             rule_obj = getattr(rules_obj(), str(pos))
             digest = rule_obj.get().get("digest")
-            rule_obj.delete(pos=pos, digest=digest)
+            rule_obj.delete(digest=digest)
 
             self.module.exit_json(changed=True, msg="successfully deleted firewall rules")
         except Exception as e:
@@ -733,6 +733,7 @@ class ProxmoxFirewallAnsible(ProxmoxSdnAnsible):
             try:
                 rule_obj = getattr(rules_obj(), str(rule["pos"]))
                 rule["digest"] = rule_obj.get().get("digest")  # Avoids concurrent changes
+                rule["pos"] = None
                 rule_obj.put(**rule)
 
             except Exception as e:


### PR DESCRIPTION
### What does this PR do?

`pos` is rejected by the Proxmox API when updating rules.

### Issue Type
<!--- Pick one below and delete the rest. -->
- Bugfix Pull Request

### Component Name
community.proxmox.proxmox_firewall

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [ ] I have considered backward compatibility.
- [ ] I haved added a changelog fragment (expect for new a module).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #485 
