### PR TITLE
fix(proxmox_vm_info): skip VM network info when VM is stopped

### DIFF
--- a/changelogs/fragments/504-vm-network-info-when-stopped.yml
+++ b/changelogs/fragments/504-vm-network-info-when-stopped.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_vm_info - skip VM network info when VM is stopped (https://github.com/ansible-collections/community.proxmox/pull/504).

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -200,13 +200,13 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                         config_type = 0 if config == "pending" else 1
                         # GET /nodes/{node}/qemu/{vmid}/config current=[0/1]
                         desired_vm["config"] = call_vm_getter(this_vm_id).config().get(current=config_type)
-                    if network:
-                        if resource_type == "qemu":
-                            desired_vm["network"] = (
-                                call_vm_getter(this_vm_id).agent("network-get-interfaces").get()["result"]
-                            )
-                        elif resource_type == "lxc":
-                            desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
+                        if network and desired_vm["status"] == "running":
+                            if resource_type == "qemu":
+                                desired_vm["network"] = (
+                                    call_vm_getter(this_vm_id).agent("network-get-interfaces").get()["result"]
+                                )
+                            elif resource_type == "lxc":
+                                desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
 
         return filtered_vms
 


### PR DESCRIPTION
### What does this PR do?

Skip gather VM network information when the VM is stopped.

### Issue Type

- Bugfix Pull Request

### Component Name

`proxmox_vm_info`

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [x] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/ansible-collections/community.proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--- If your PR fully resolves and should close the linked issue, use Fixes. Otherwise, use Relates --->
Fixes #495
