### PR TITLE
style(ruff): ignore rule PLR0917

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -22,6 +22,7 @@ ignore = [
     "D107", # undocumented-public-init
     "D203", # incorrect-blank-line-before-class, mutually exclusive to D211
     "D212", # multi-line-summary-first-line, mutually exclusive to D213
+    "PLR0917", # too-many-positional-only-arguments
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
### What does this PR do?

Ignore the Ruff rule [PLR0917](https://docs.astral.sh/ruff/rules/too-many-positional-arguments/).

I think it's safe to ignore this rule entierly, Ansible module contains very often lot of positional args and there are false positive.

This will ignore 19 issues:

```txt
plugins/modules/proxmox.py:859:9: [PLR0917]
  Too many positional arguments (7 > 5)
  ⋮ │ 
857 │         )
858 │ 
859 │     def lxc_absent(self, vmid, hostname, node, timeout, purge, destroy_unreferenced_disks, force):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔
860 │         try:
  ⋮ │ 

plugins/modules/proxmox.py:1045:9: [PLR0917]
  Too many positional arguments (6 > 5)
   ⋮ │ 
1043 │         getattr(proxmox_node, self.VZ_TYPE)(vmid).config.put(vmid=vmid, node=node, **kwargs)
1044 │ 
1045 │     def new_lxc_instance(self, vmid, hostname, node, clone_from, ostemplate, force):  # noqa: PLR0913
     │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
1046 │         identifier = self.format_vm_identifier(vmid, hostname)
   ⋮ │ 

plugins/modules/proxmox.py:1267:9: [PLR0917]
  Too many positional arguments (6 > 5)
   ⋮ │ 
1265 │         )
1266 │ 
1267 │     def remove_lxc_instance(self, vmid, node, timeout, purge, destroy_unreferenced_disks, force):  # noqa: PLR0913
     │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
1268 │         delete_params = {}
   ⋮ │ 

plugins/modules/proxmox.py:1430:9: [PLR0917]
  Too many positional arguments (9 > 5)
   ⋮ │ 
1428 │         return disk_kwargs
1429 │ 
1430 │     def build_volume(  # noqa: PLR0912, PLR0913
     │         ▔▔▔▔▔▔▔▔▔▔▔▔
1431 │         self,
   ⋮ │ 

plugins/modules/proxmox_backup.py:425:9: [PLR0917]
  Too many positional arguments (8 > 5)
  ⋮ │ 
423 │         return tasks
424 │ 
425 │     def permission_check(self, storage, mode, node, bandwidth, performance_tweaks, retention, pool, vmids):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
426 │         permissions = self._get_permissions()
  ⋮ │ 

plugins/modules/proxmox_cluster_ha_groups.py:125:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
123 │         return self.proxmox_api.cluster.ha.groups(name).delete()
124 │ 
125 │     def create(self, groups, name, comment, nodes, nofailback, restricted):  # noqa: PLR0913
    │         ▔▔▔▔▔▔
126 │         data = {
  ⋮ │ 

plugins/modules/proxmox_cluster_ha_resources.py:147:9: [PLR0917]
  Too many positional arguments (7 > 5)
  ⋮ │ 
145 │         return self.proxmox_api.cluster.ha.resources(sid).delete()
146 │ 
147 │     def create(self, resources, sid, comment, group, max_relocate, max_restart, state):  # noqa: PLR0913
    │         ▔▔▔▔▔▔
148 │         data = {
  ⋮ │ 

plugins/modules/proxmox_kvm.py:1113:9: [PLR0917]
  Too many positional arguments (10 > 5)
   ⋮ │ 
1111 │         return False
1112 │ 
1113 │     def create_vm(self, vmid, newid, node, name, memory, cpu, cores, sockets, update, update_unsafe, **kwargs):  # noqa: PLR0912, PLR0913, PLR0915
     │         ▔▔▔▔▔▔▔▔▔
1114 │         # Available only in PVE 4
   ⋮ │ 

plugins/modules/proxmox_snap.py:190:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
188 │         return mountpoints
189 │ 
190 │     def _container_mp_disable(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
191 │         # shutdown container if running
  ⋮ │ 

plugins/modules/proxmox_snap.py:197:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
195 │         self.vmconfig(vm, vmid).put(delete=" ".join(mountpoints))
196 │ 
197 │     def _container_mp_restore(self, vm, vmid, timeout, unbind, mountpoints, vmstatus):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
198 │         # NOTE: requires auth as `root@pam`, API tokens are not supported
  ⋮ │ 

plugins/modules/proxmox_snap.py:242:9: [PLR0917]
  Too many positional arguments (8 > 5)
  ⋮ │ 
240 │                 self.snapshot(vm, vmid)(snap["name"]).delete()
241 │ 
242 │     def snapshot_create(self, vm, vmid, timeout, snapname, description, vmstate, unbind, retention):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
243 │         if self.module.check_mode:
  ⋮ │ 

plugins/modules/proxmox_template.py:256:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
254 │             self.module.fail_json(msg=f"Uploading template {realpath} failed with error: {e}")
255 │ 
256 │     def fetch_template(self, node, storage, content_type, url, timeout, template):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔
257 │         """Fetch a template from a web url source using the proxmox download-url endpoint"""
  ⋮ │ 

plugins/modules/proxmox_template.py:288:9: [PLR0917]
  Too many positional arguments (8 > 5)
  ⋮ │ 
286 │         return False
287 │ 
288 │     def fetch_and_verify(self, node, storage, url, content_type, timeout, checksum, checksum_algorithm, template):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
289 │         """Fetch a template from a web url, then verify it using a checksum."""
  ⋮ │ 

plugins/modules/proxmox_user.py:211:9: [PLR0917]
  Too many positional arguments (9 > 5)
  ⋮ │ 
209 │                 self.module.fail_json(msg=f"Unable to retrieve user {userid}: {e}")
210 │ 
211 │     def _user_needs_update(self, existing_user, comment, email, enable, expire, firstname, lastname, groups, keys):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
212 │         """Check if user needs updating by comparing current vs desired state"""
  ⋮ │ 

plugins/modules/proxmox_user.py:312:9: [PLR0917]
  Too many positional arguments (11 > 5)
  ⋮ │ 
310 │         return result_tokens
311 │ 
312 │     def create_update_user(  # noqa: PLR0913 PLR0912
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
313 │         self,
  ⋮ │ 

plugins/modules/proxmox_vm_info.py:170:9: [PLR0917]
  Too many positional arguments (7 > 5)
  ⋮ │ 
168 │             self.module.fail_json(msg=f"Failed to retrieve VMs information from cluster resources: {e}")
169 │ 
170 │     def get_vms_from_nodes(  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
171 │         self, cluster_machines, resource_type, vmid=None, name=None, node=None, config=None, network=False
  ⋮ │ 

plugins/modules/proxmox_vm_info.py:213:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
211 │         return filtered_vms
212 │ 
213 │     def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔▔
214 │         try:
  ⋮ │ 

plugins/modules/proxmox_vm_info.py:219:9: [PLR0917]
  Too many positional arguments (6 > 5)
  ⋮ │ 
217 │             self.module.fail_json(msg=f"Failed to retrieve QEMU VMs information: {e}")
218 │ 
219 │     def get_lxc_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
    │         ▔▔▔▔▔▔▔▔▔▔▔
220 │         try:
  ⋮ │ 

tests/unit/plugins/modules/test_proxmox_node.py:28:5: [PLR0917]
  Too many positional arguments (8 > 5)
 ⋮ │ 
27 │ 
28 │ def get_certificate_module_args(  # noqa:PLR0913
   │     ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
29 │     cert=None,
```

### Issue Type

- Refactoring Pull Request


### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [ ] I have run unit tests.
- [ ] I have run integration.
- [ ] I have considered backward compatibility.
- [ ] I haved added a changelog fragment (expect for new a module).

