### PR TITLE
fix(proxmox_vm): ignore guest agent error of network info

### DIFF
--- a/changelogs/fragments/507-proxmox_vm_info-ignore-guest-agent-error.yml
+++ b/changelogs/fragments/507-proxmox_vm_info-ignore-guest-agent-error.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - proxmox_vm_info - ignore errors when retrieving VM network info if the QEMU guest agent is not running (https://github.com/ansible-collections/community.proxmox/pull/507).

--- a/plugins/modules/proxmox_vm_info.py
+++ b/plugins/modules/proxmox_vm_info.py
@@ -201,14 +201,22 @@ class ProxmoxVmInfoAnsible(ProxmoxAnsible):
                         # GET /nodes/{node}/qemu/{vmid}/config current=[0/1]
                         desired_vm["config"] = call_vm_getter(this_vm_id).config().get(current=config_type)
                         if network and desired_vm["status"] == "running":
-                            if resource_type == "qemu":
-                                desired_vm["network"] = (
-                                    call_vm_getter(this_vm_id).agent("network-get-interfaces").get()["result"]
-                                )
-                            elif resource_type == "lxc":
-                                desired_vm["network"] = call_vm_getter(this_vm_id).interfaces.get()
+                            desired_vm["network"] = self.get_vm_network(call_vm_getter, this_vm_id, resource_type)
 
         return filtered_vms
+
+    def get_vm_network(self, call_vm_getter, vmid, resource_type):
+        try:
+            if resource_type == "qemu":
+                return call_vm_getter(vmid).agent("network-get-interfaces").get()["result"]
+            if resource_type == "lxc":
+                return call_vm_getter(vmid).interfaces.get()
+        except Exception as e:
+            msg = f"Failed to retrieve network information for {resource_type} VM {vmid}: {e}"
+            if "QEMU guest agent is not running" in str(e):
+                self.module.warn(msg)
+                return []
+            self.module.fail_json(msg)
 
     def get_qemu_vms(self, cluster_machines, vmid=None, name=None, node=None, config=None, network=False):  # noqa: PLR0913
         try:


### PR DESCRIPTION
### What does this PR do?

Ignore the error of VM network gathering information when VM is running AND guest-agent not running.

Previous PR was skipping VM network info when not running. Here it's ignore the error related to guest-agent not running.

This second issue related to VM network info has been reported by @Zocker1999NET https://github.com/ansible-collections/community.proxmox/pull/504#issuecomment-5388445566


### Issue Type

- Bugfix Pull Request

### Component Name

`proxmox_vm_info`

### Contributor's Note
<!---
Please mark the following items with an [x] *IF* they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `nox` and fixed any issues.
- [ ] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [x] I have run integration.
- [x] I have considered backward compatibility.
- [x] I haved added a changelog fragment (expect for new a module).

Relates https://github.com/ansible-collections/community.proxmox/issues/495 #504
