### PR TITLE
fix(proxmox_node_firewall_options): apply state=disabled without host.fw

### DIFF
--- a/changelogs/fragments/511-node-firewall-options-enable-default.yml
+++ b/changelogs/fragments/511-node-firewall-options-enable-default.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - proxmox_node_firewall_options - apply ``state=disabled`` on a node whose ``host.fw`` does not set ``enable`` (https://github.com/ansible-collections/community.proxmox/issues/511).
+  - proxmox_node_firewall_options_info - report ``enabled`` as ``true`` for a node whose ``host.fw`` does not set ``enable`` (https://github.com/ansible-collections/community.proxmox/issues/511).

--- a/plugins/module_utils/proxmox_node_firewall_options.py
+++ b/plugins/module_utils/proxmox_node_firewall_options.py
@@ -10,7 +10,8 @@ from ansible_collections.community.proxmox.plugins.module_utils.proxmox import (
 SCHEMA = {
     "enabled": {
         "api": "enable",
-        "default": False,
+        # Proxmox VE enables the host firewall unless host.fw states 'enable: 0'
+        "default": True,
         "to_api": ansible_to_proxmox_bool,
         "from_api": proxmox_to_ansible_bool,
     },

--- a/tests/unit/plugins/modules/test_proxmox_node_firewall_options.py
+++ b/tests/unit/plugins/modules/test_proxmox_node_firewall_options.py
@@ -150,6 +150,29 @@ class TestProxmoxNodeFirewallOptionsModule(ModuleTestCase):
         assert payload["enable"] == 1
         assert payload["nftables"] == 1
 
+    def test_disable_firewall_on_node_without_host_fw(self):
+        self.mock_api_fw_options.get.side_effect = [{}, {"enable": 0}]
+
+        result = self._run_module(build_module_args(state="disabled"))
+
+        assert result["changed"] is True
+        assert result["msg"] == "Node firewall options updated"
+        assert result["enabled"] is False
+
+        assert self.mock_api_fw_options.put.called
+        payload = self.mock_api_fw_options.put.call_args[1]
+        assert payload["enable"] == 0
+
+    def test_idempotent_when_host_fw_only_disables_the_firewall(self):
+        self.mock_api_fw_options.get.return_value = {"enable": 0}
+
+        result = self._run_module(build_module_args(state="disabled"))
+
+        assert result["changed"] is False
+        assert result["msg"] == "Node firewall options already match desired state"
+        assert result["enabled"] is False
+        assert not self.mock_api_fw_options.put.called
+
     def test_disable_firewall_updates_enable_flag(self):
         self.mock_api_fw_options.get.side_effect = [
             SAMPLE_API_NODE_FIREWALL_OPTIONS,


### PR DESCRIPTION
### What does this PR do?

Proxmox VE enables the host firewall unless `host.fw` states `enable: 0`, and the
API returns that file without filling in defaults. The module read a missing
`enable` as *disabled*. On a node that has no `host.fw` yet, `state: disabled`
therefore did nothing, and the node kept filtering host traffic.

- `state: enabled` on such a node now reports no change instead of writing the
  file. Proxmox VE already treats it as enabled, so there is nothing to do.
- `proxmox_node_firewall_options_info` reports `enabled: true` for such a node
  instead of `false`.

Details in #511.

### Issue Type
- Bugfix Pull Request

### Component Name
proxmox_node_firewall_options, proxmox_node_firewall_options_info

### Contributor's Note
- [ ] I have run `nox` and fixed any issues.
- [x] I have added / updated unit tests (**required** for new modules and bug fixes).
- [x] I have run unit tests.
- [ ] I have run integration.
- [x] I have considered backward compatibility - it "does" change the playbooks behaviour for hosts without a host.fw
- [x] I haved added a changelog fragment (expect for new a module).

Fixes #511