### PR TITLE
fix(proxmox): correct LXC update payload for local backend

### DIFF
--- a/changelogs/fragments/513-lxc-local-update.yml
+++ b/changelogs/fragments/513-lxc-local-update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - proxmox - omit path parameters from LXC configuration update payloads and serialize tags as a semicolon-separated string, fixing updates with the local backend (https://github.com/ansible-collections/community.proxmox/issues/513).

--- a/plugins/modules/proxmox.py
+++ b/plugins/modules/proxmox.py
@@ -1040,7 +1040,10 @@ class ProxmoxLxcAnsible(ProxmoxAnsible):
             self.module.exit_json(changed=False, vmid=vmid, msg="Container config is already up to date.")
 
         # update the config
-        getattr(proxmox_node, self.VZ_TYPE)(vmid).config.put(vmid=vmid, node=node, **kwargs)
+        for arg, sep in _LIST_FIELDS.items():
+            if arg in kwargs:
+                kwargs[arg] = sep.join(kwargs[arg])
+        getattr(proxmox_node, self.VZ_TYPE)(vmid).config.put(**kwargs)
 
     def new_lxc_instance(self, vmid, hostname, node, clone_from, ostemplate, force):  # noqa: PLR0913
         identifier = self.format_vm_identifier(vmid, hostname)

--- a/tests/unit/plugins/modules/test_proxmox_lxc.py
+++ b/tests/unit/plugins/modules/test_proxmox_lxc.py
@@ -5,6 +5,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.compat.version import LooseVersion
 
@@ -32,3 +33,53 @@ def test_mount_formatting(mock_api, *_):
     ]
     mounts = lxc_ansible.process_mount_keys(100, "my-node", None, mount_volumes)
     assert mounts == {"mp0": "/mnt/dir,mp=mnt/dir"}
+
+
+@pytest.fixture
+def lxc_ansible():
+    instance = proxmox.ProxmoxLxcAnsible.__new__(proxmox.ProxmoxLxcAnsible)
+    instance.VZ_TYPE = "lxc"
+    instance.module = MagicMock(spec=AnsibleModule)
+    instance.proxmox_api = MagicMock()
+    return instance
+
+
+@pytest.mark.parametrize(
+    ("current", "requested", "expected"),
+    [
+        ({}, {"hostname": "my-lxc"}, {"hostname": "my-lxc"}),
+        ({}, {"tags": ["foo"]}, {"tags": "foo"}),
+        ({"tags": "old"}, {"tags": ["foo", "bar"]}, {"tags": "foo;bar"}),
+        ({"tags": "foo"}, {"tags": []}, {"tags": ""}),
+        ({"tags": "foo"}, {"tags": None, "hostname": "my-lxc"}, {"hostname": "my-lxc"}),
+        (
+            {"tags": "bar;foo", "hostname": "old"},
+            {"tags": ["foo", "bar"], "hostname": "my-lxc"},
+            {"tags": "foo;bar", "hostname": "my-lxc"},
+        ),
+    ],
+)
+def test_update_lxc_payload(lxc_ansible, current, requested, expected):
+    config = lxc_ansible.proxmox_api.nodes.return_value.lxc.return_value.config
+    config.get.return_value = current
+
+    lxc_ansible.update_lxc_instance(1003, "example", **requested)
+
+    lxc_ansible.proxmox_api.nodes.assert_called_once_with("example")
+    lxc_ansible.proxmox_api.nodes.return_value.lxc.assert_called_with(1003)
+    config.put.assert_called_once_with(**expected)
+
+
+@pytest.mark.parametrize(("current", "tags"), [("bar;foo", ["foo", "bar"]), ("", [])])
+def test_update_lxc_tags_unchanged(lxc_ansible, current, tags):
+    config = lxc_ansible.proxmox_api.nodes.return_value.lxc.return_value.config
+    config.get.return_value = {"tags": current}
+    lxc_ansible.module.exit_json.side_effect = SystemExit
+
+    with pytest.raises(SystemExit):
+        lxc_ansible.update_lxc_instance(1003, "example", tags=tags)
+
+    lxc_ansible.module.exit_json.assert_called_once_with(
+        changed=False, vmid=1003, msg="Container config is already up to date."
+    )
+    config.put.assert_not_called()


### PR DESCRIPTION
### What does this PR do?

Fix LXC configuration updates with the local backend. Updates currently pass `node` and `vmid` in both the API path and the request body, causing `pvesh` to reject them as unknown options. Tag lists also reach the API without the required string serialization.

Remove the redundant path parameters from the update body and serialize tags as a semicolon-separated string after the idempotency comparison. Regression tests cover updates without tags, single and multiple tags, clearing tags, omitted tags, and unchanged tags in a different order.

Fixes #513.

### Issue Type

- Bugfix Pull Request

### Component Name

community.proxmox.proxmox

### Validation

- Targeted LXC unit tests: 9 passed, including a rerun after rebasing onto upstream/main.
- Targeted ansible-test sanity: passed.
- Nox formatters and git diff whitespace checks: passed.
- Full codeqa: existing `PLR0917` positional-argument warnings; the changed module has the same warnings as the baseline, and the changed test file passes Ruff.
- Integration tests: not run; requires a Proxmox environment.

### Contributor's Note

- [x] Added regression tests and a changelog fragment.
- [x] Considered backward compatibility: tag comparison remains order-independent; omitted tags remain omitted.
- [x] Implemented with AI assistance from OpenAI Codex; commit includes Codex co-authorship.
